### PR TITLE
fix(compose): add container_name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
 
 
   slimfaas:
+    container_name: slimfaas-1
     image: axaguildev/slimfaas:latest
    # build:
    #   context: .


### PR DESCRIPTION
Adding the "container_name" key to the slimfaas container in the docker-compose.yml file to match its HOSTNAME environment variable