### PR TITLE
feat(otel): Do not filter out logs by path

### DIFF
--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -286,9 +286,9 @@ docker run --rm -p 8080:8080 \
 - When `Enable` is `false`, OpenTelemetry instrumentation is completely disabled to avoid unnecessary overhead
 - The `ServiceName` is optional; if not specified in configuration, it automatically falls back to the `OTEL_SERVICE_NAME` environment variable (this is the default OpenTelemetry behavior)
 - The `Endpoint` automatically falls back to `OTEL_EXPORTER_OTLP_ENDPOINT` if not specified in configuration (this is the default OpenTelemetry behavior)
-- **URL exclusion**: URLs specified in `ExcludedUrls` are filtered from **both tracing and logging** based on **case-insensitive path prefix matching**. For example, `/health` will exclude `/health`, `/health/live`, `/health/ready`, etc.
+- **URL exclusion**: URLs specified in `ExcludedUrls` are filtered from tracing based on **case-insensitive path prefix matching**. For example, `/health` will exclude `/health`, `/health/live`, `/health/ready`, etc.
 - Empty or missing `ExcludedUrls` configuration will use the default values `["/health", "/metrics"]`
-- URL filtering applies to **traces and logs**; metrics are not affected
+- URL filtering only applies to **traces**; metrics and logs are not affected
 
 The instrumentation includes:
 - **Traces**: ASP.NET Core requests, HTTP client calls

--- a/documentation/opentelemetry.md
+++ b/documentation/opentelemetry.md
@@ -25,7 +25,7 @@ SlimFaas provides built-in support for OpenTelemetry, enabling comprehensive obs
 | `ServiceName` | Optional    | String       | Name of the service for tracing                                                           | Helps identify traces in your observability platform | `"SlimFaas"` |
 | `Endpoint` | Conditional | String (URL) | OTLP exporter endpoint (gRPC)                                                             | Required if `Enable` is `true`                       | `"http://localhost:4317"` |
 | `EnableConsoleExporter` | Optional    | Boolean      | Export to console for debugging                                                           | Useful for local development                         | `false` |
-| `ExcludedUrls`        |  Optional   | string array | List of URL path prefixes to exclude from tracing and logging |                | `["/health", "/metrics"]` |
+| `ExcludedUrls`        |  Optional   | string array | List of URL path prefixes to exclude from tracing |                | `["/health", "/metrics"]` |
 
 **Configuration Priority (default behavior):**
 1. Configuration values from `appsettings.json` (highest priority)
@@ -84,9 +84,7 @@ SlimFaas automatically instruments:
 ### Logs
 
 - ✅ **Application logs** exported via OTLP
-- URLs specified in `ExcludedUrls` are **also filtered from logs** based on **case-insensitive path prefix matching**
-- Log filtering applies to requests where the route path matches any excluded URL prefix
-- Empty or missing `ExcludedUrls` configuration will use the default values `["/health", "/metrics"]`
+- **Note**: URL filtering does **not** apply to logs; all logs are collected regardless of `ExcludedUrls`
 
 ### Metrics
 

--- a/src/SlimFaas/Extensions/OpenTelemetryExtensions.cs
+++ b/src/SlimFaas/Extensions/OpenTelemetryExtensions.cs
@@ -1,4 +1,3 @@
-using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -118,54 +117,9 @@ public static class OpenTelemetryExtensions
                 : _ => { }
         );
 
-        if (config.ExcludedUrls is { Length: > 0 })
-        {
-            loggerProviderBuilder.AddProcessor(new ExcludeUrlLogProcessor(config.ExcludedUrls));
-        }
-
         if (config.EnableConsoleExporter)
         {
             loggerProviderBuilder.AddConsoleExporter();
         }
-    }
-}
-
-internal class ExcludeUrlLogProcessor(string[] excludedUrls) : BaseProcessor<LogRecord>
-{
-    public override void OnEnd(LogRecord data)
-    {
-        if (ShouldExclude(data))
-        {
-            return;
-        }
-
-        base.OnEnd(data);
-    }
-
-    private bool ShouldExclude(LogRecord data)
-    {
-        if (data.Attributes == null)
-        {
-            return false;
-        }
-
-        var path = data.Attributes.FirstOrDefault(kvp =>
-            kvp.Key == "Path" || kvp.Key == "RequestPath" || kvp.Key == "url.path")
-            .Value?.ToString() ?? string.Empty;
-
-        if (string.IsNullOrEmpty(path))
-        {
-            return false;
-        }
-
-        foreach (var excludedUrl in excludedUrls)
-        {
-            if (path.StartsWith(excludedUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/SlimFaasMcp/Extensions/OpenTelemetryExtensions.cs
+++ b/src/SlimFaasMcp/Extensions/OpenTelemetryExtensions.cs
@@ -1,4 +1,3 @@
-using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -118,54 +117,9 @@ public static class OpenTelemetryExtensions
                 : _ => { }
         );
 
-        if (config.ExcludedUrls is { Length: > 0 })
-        {
-            loggerProviderBuilder.AddProcessor(new ExcludeUrlLogProcessor(config.ExcludedUrls));
-        }
-
         if (config.EnableConsoleExporter)
         {
             loggerProviderBuilder.AddConsoleExporter();
         }
-    }
-}
-
-internal class ExcludeUrlLogProcessor(string[] excludedUrls) : BaseProcessor<LogRecord>
-{
-    public override void OnEnd(LogRecord data)
-    {
-        if (ShouldExclude(data))
-        {
-            return;
-        }
-
-        base.OnEnd(data);
-    }
-
-    private bool ShouldExclude(LogRecord data)
-    {
-        if (data.Attributes == null)
-        {
-            return false;
-        }
-
-        var path = data.Attributes.FirstOrDefault(kvp =>
-            kvp.Key == "Path" || kvp.Key == "RequestPath" || kvp.Key == "url.path")
-            .Value?.ToString() ?? string.Empty;
-
-        if (string.IsNullOrEmpty(path))
-        {
-            return false;
-        }
-
-        foreach (var excludedUrl in excludedUrls)
-        {
-            if (path.StartsWith(excludedUrl, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/SlimFaasMcp/Middleware/RequestLoggingMiddleware.cs
+++ b/src/SlimFaasMcp/Middleware/RequestLoggingMiddleware.cs
@@ -1,6 +1,4 @@
 using System.Text;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 
 namespace SlimFaasMcp.Middleware;
 
@@ -29,6 +27,12 @@ public sealed class RequestLoggingMiddleware
         }
 
         var request = context.Request;
+
+        if (request.Path.Value != "/mcp")
+        {
+            await _next(context);
+            return;
+        }
 
         // Headers (tronqués pour éviter de log trop gros)
         var headers = string.Join(", ",

--- a/tests/SlimFaasMcp.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/SlimFaasMcp.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -59,6 +59,52 @@ public class RequestLoggingMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_WhenPathIsNotMcp_DoNotLog()
+    {
+        // Arrange
+        var loggerMock = new Mock<ILogger<RequestLoggingMiddleware>>();
+        loggerMock
+            .Setup(l => l.IsEnabled(LogLevel.Debug))
+            .Returns(true);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "POST";
+        httpContext.Request.Path = "/health";
+        httpContext.Request.QueryString = new QueryString("?q=test");
+        httpContext.Request.ContentType = "application/json";
+        httpContext.Request.Headers["X-Test"] = "HelloHeader";
+
+        var bodyJson = """{"hello":"world"}""";
+        var bodyBytes = Encoding.UTF8.GetBytes(bodyJson);
+        httpContext.Request.Body = new MemoryStream(bodyBytes);
+        httpContext.Request.ContentLength = bodyBytes.Length;
+
+        bool nextCalled = false;
+        RequestDelegate next = ctx =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        };
+
+        var middleware = new RequestLoggingMiddleware(next, loggerMock.Object);
+
+        // Act
+        await middleware.InvokeAsync(httpContext);
+
+        // Assert
+        Assert.True(nextCalled);
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task InvokeAsync_LargeBody_IsTruncatedInLog()
     {
         // Arrange


### PR DESCRIPTION
It does not seem possible to filter out log based on path with the openTelemetry nuget.
For SlimFaasMcp, only log path /mcp.