### PR TITLE
fix(jobs): preserve initial env-var job configurations after k8s sync

### DIFF
--- a/src/SlimFaas/Jobs/JobConfiguration.cs
+++ b/src/SlimFaas/Jobs/JobConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SlimFaas.Kubernetes;
 using SlimFaas.Options;
@@ -95,23 +94,17 @@ public class JobConfiguration : IJobConfiguration
         var mergedConfigurations = new Dictionary<string, SlimfaasJob>(StringComparer.OrdinalIgnoreCase);
         var mergedSchedules = new Dictionary<string, IList<ScheduleCreateJob>>(StringComparer.OrdinalIgnoreCase);
 
-        if (_initialConfiguration.Configurations.TryGetValue(Default, out var defaultJob))
-        {
-            mergedConfigurations[Default] = defaultJob;
-        }
+        foreach (var kvp in _initialConfiguration.Configurations)
+            mergedConfigurations[kvp.Key] = kvp.Value;
 
-        if (_initialConfiguration.Schedules != null && _initialConfiguration.Schedules.TryGetValue(Default, out var defaultSchedule))
-        {
-            mergedSchedules[Default] = defaultSchedule;
-        }
+        if (_initialConfiguration.Schedules != null)
+            foreach (var kvp in _initialConfiguration.Schedules)
+                mergedSchedules[kvp.Key] = kvp.Value;
 
         foreach (var kvp in configuration.Configurations)
         {
             if (kvp.Key.Equals(Default, StringComparison.OrdinalIgnoreCase))
-            {
                 continue;
-            }
-
             mergedConfigurations[kvp.Key] = kvp.Value;
         }
 
@@ -120,15 +113,12 @@ public class JobConfiguration : IJobConfiguration
             foreach (var kvp in configuration.Schedules)
             {
                 if (kvp.Key.Equals(Default, StringComparison.OrdinalIgnoreCase))
-                {
                     continue;
-                }
-
                 mergedSchedules[kvp.Key] = kvp.Value;
             }
         }
 
-        return new SlimFaasJobConfiguration(mergedConfigurations, mergedSchedules);
+        return new SlimFaasJobConfiguration(mergedConfigurations, mergedSchedules.Count > 0 ? mergedSchedules : null);
     }
 
     public async Task SyncJobsConfigurationAsync()

--- a/tests/SlimFaas.Tests/Jobs/JobConfigurationSyncTests.cs
+++ b/tests/SlimFaas.Tests/Jobs/JobConfigurationSyncTests.cs
@@ -82,7 +82,7 @@ public class JobConfigurationSyncTests
         Assert.Equal("k8s-image:v1", sut.Configuration.Configurations["k8s-job"].Image);
     }
 
-    [Fact(DisplayName = "Sync: only initial Default job is preserved, non-default jobs come from k8s")]
+    [Fact(DisplayName = "Sync: initial env jobs are preserved and k8s jobs are added (true merge)")]
     public async Task SyncAsync_PreservesOnlyInitialDefaultJob()
     {
         // Arrange – initial config has "env-job"
@@ -117,9 +117,12 @@ public class JobConfigurationSyncTests
         // Act
         await sut.SyncJobsConfigurationAsync();
 
-        // Assert – non-default initial jobs are replaced by synced k8s jobs
-        Assert.False(sut.Configuration.Configurations.ContainsKey("env-job"));
-        Assert.True(sut.Configuration.Configurations.ContainsKey("k8s-job"));
+        // Assert – initial env jobs are preserved AND k8s jobs are added
+        Assert.True(sut.Configuration.Configurations.ContainsKey("env-job"),
+            "env-job from initial config (env var) must be preserved after sync");
+        Assert.Equal("env-image:v1", sut.Configuration.Configurations["env-job"].Image);
+        Assert.True(sut.Configuration.Configurations.ContainsKey("k8s-job"),
+            "k8s-job from Kubernetes must be added during sync");
         Assert.True(sut.Configuration.Configurations.ContainsKey("Default"));
     }
 


### PR DESCRIPTION
MergeJobConfigurations was only keeping the "Default" entry from _initialConfiguration, causing jobs and schedules defined via SlimFaas__JobsConfiguration to be lost after the first sync cycle.

Now all entries from _initialConfiguration are used as the merge base, with Kubernetes CronJob configurations overlaid on top (excluding "Default" to prevent accidental override).

Updated SyncAsync_PreservesOnlyInitialDefaultJob test to reflect the correct merge behaviour.