### PR TITLE
Fix #293: ttl must work with sets incr command

### DIFF
--- a/documentation/data-sets.md
+++ b/documentation/data-sets.md
@@ -34,11 +34,11 @@ Base path: `/data/sets`
 | Method | Path | Purpose |
 |---|---|---|
 | `POST` | `/data/sets?id={id?}&ttl={ttl_ms?}` | Create or overwrite a value |
-| `POST` | `/data/sets/{id}/incr` | Atomically increment an integer by 1 |
-| `POST` | `/data/sets/{id}/incrby?by={long}` | Atomically increment an integer by `by` |
-| `POST` | `/data/sets/{id}/incrbyfloat?by={decimal}` | Atomically increment a decimal value by `by` |
-| `POST` | `/data/sets/{id}/decr` | Atomically decrement an integer by 1 |
-| `POST` | `/data/sets/{id}/decrby?by={long}` | Atomically decrement an integer by `by` |
+| `POST` | `/data/sets/{id}/incr?ttl={ttl_ms?}` | Atomically increment an integer by 1 |
+| `POST` | `/data/sets/{id}/incrby?by={long}&ttl={ttl_ms?}` | Atomically increment an integer by `by` |
+| `POST` | `/data/sets/{id}/incrbyfloat?by={decimal}&ttl={ttl_ms?}` | Atomically increment a decimal value by `by` |
+| `POST` | `/data/sets/{id}/decr?ttl={ttl_ms?}` | Atomically decrement an integer by 1 |
+| `POST` | `/data/sets/{id}/decrby?by={long}&ttl={ttl_ms?}` | Atomically decrement an integer by `by` |
 | `GET` | `/data/sets/{id}` | Read a value |
 | `GET` | `/data/sets` | List entries (IDs + expiration) |
 | `DELETE` | `/data/sets/{id}` | Delete a value |
@@ -105,20 +105,22 @@ Supported operations:
 
 | Command | HTTP endpoint | Stored value type | Response |
 |---|---|---|---|
-| `INCR` | `POST /data/sets/{id}/incr` | UTF-8 integer | new integer value |
-| `INCRBY` | `POST /data/sets/{id}/incrby?by={long}` | UTF-8 integer | new integer value |
-| `INCRBYFLOAT` | `POST /data/sets/{id}/incrbyfloat?by={decimal}` | UTF-8 decimal | new decimal value |
-| `DECR` | `POST /data/sets/{id}/decr` | UTF-8 integer | new integer value |
-| `DECRBY` | `POST /data/sets/{id}/decrby?by={long}` | UTF-8 integer | new integer value |
+| `INCR` | `POST /data/sets/{id}/incr?ttl={ttl_ms?}` | UTF-8 integer | new integer value |
+| `INCRBY` | `POST /data/sets/{id}/incrby?by={long}&ttl={ttl_ms?}` | UTF-8 integer | new integer value |
+| `INCRBYFLOAT` | `POST /data/sets/{id}/incrbyfloat?by={decimal}&ttl={ttl_ms?}` | UTF-8 decimal | new decimal value |
+| `DECR` | `POST /data/sets/{id}/decr?ttl={ttl_ms?}` | UTF-8 integer | new integer value |
+| `DECRBY` | `POST /data/sets/{id}/decrby?by={long}&ttl={ttl_ms?}` | UTF-8 integer | new integer value |
 
 Rules:
 
 - Missing or expired keys start from `0`.
 - Integer commands require the existing value to be a strict UTF-8 integer.
 - `INCRBYFLOAT` requires the existing value to be a strict UTF-8 decimal number.
-- Numeric mutations preserve the existing TTL.
-- If a key has expired, the old value and TTL are ignored and removed before applying the mutation.
-- Invalid numeric values or integer overflows return **409 Conflict** and do not mutate the stored value.
+- When `ttl` is omitted, numeric mutations **preserve** the existing TTL. Keys without an existing TTL stay without one.
+- When `ttl > 0` is provided (milliseconds), it **applies or overrides** the TTL on the key — even if the key had none, or the key was created by this very command.
+- `ttl <= 0` (or otherwise invalid) returns **400 Bad Request** without mutating the stored value.
+- If a key has expired, the old value and TTL are ignored and removed before applying the mutation. A `ttl` provided on the request is still applied to the new value.
+- Invalid numeric values or integer overflows return **409 Conflict** and do not mutate the stored value or its TTL.
 - Responses are `text/plain` and contain the new value.
 
 Examples:
@@ -145,6 +147,12 @@ Increment a decimal value:
 ```bash
 curl -X POST "http://<slimfaas>/data/sets/cost-total/incrbyfloat?by=1.25"
 # 1.25
+```
+
+Increment a counter and set its TTL to 60 seconds atomically:
+```bash
+curl -X POST "http://<slimfaas>/data/sets/request-count/incr?ttl=60000"
+# 1
 ```
 
 Read the stored counter value:

--- a/src/SlimData/SlimDataInterpreter.cs
+++ b/src/SlimData/SlimDataInterpreter.cs
@@ -546,7 +546,13 @@ public class SlimDataInterpreter : CommandInterpreter
         }
 
         var bytes = Encoding.UTF8.GetBytes(next.ToString(CultureInfo.InvariantCulture));
-        state.KeyValues = keyValues.SetItem(item.Key, bytes);
+        keyValues = keyValues.SetItem(item.Key, bytes);
+        if (item.ExpireAtUtcTicks.HasValue)
+        {
+            var ttlBytes = BitConverter.GetBytes(item.ExpireAtUtcTicks.Value);
+            keyValues = keyValues.SetItem(TtlKey(item.Key), ttlBytes);
+        }
+        state.KeyValues = keyValues;
         result.SetApplied(bytes, integerValue: next);
     }
 
@@ -579,7 +585,13 @@ public class SlimDataInterpreter : CommandInterpreter
         }
 
         var bytes = Encoding.UTF8.GetBytes(next.ToString("G29", CultureInfo.InvariantCulture));
-        state.KeyValues = keyValues.SetItem(item.Key, bytes);
+        keyValues = keyValues.SetItem(item.Key, bytes);
+        if (item.ExpireAtUtcTicks.HasValue)
+        {
+            var ttlBytes = BitConverter.GetBytes(item.ExpireAtUtcTicks.Value);
+            keyValues = keyValues.SetItem(TtlKey(item.Key), ttlBytes);
+        }
+        state.KeyValues = keyValues;
         result.SetApplied(bytes, decimalValue: next);
     }
 

--- a/src/SlimFaas/Data/DataSetRoutes.cs
+++ b/src/SlimFaas/Data/DataSetRoutes.cs
@@ -110,21 +110,21 @@ public static class DataSetRoutes
             return Results.Ok(elementId);
         }
 
-        public static Task<IResult> IncrAsync(IDatabaseService db, string id) =>
-            IntegerMutationAsync(db, id, 1);
+        public static Task<IResult> IncrAsync(IDatabaseService db, string id, long? ttl = null) =>
+            IntegerMutationAsync(db, id, 1, ttl);
 
-        public static async Task<IResult> IncrByAsync(IDatabaseService db, string id, long? by)
+        public static async Task<IResult> IncrByAsync(IDatabaseService db, string id, long? by, long? ttl = null)
         {
             if (!by.HasValue)
                 return Results.BadRequest("Missing by.");
 
-            return await IntegerMutationAsync(db, id, by.Value).ConfigureAwait(false);
+            return await IntegerMutationAsync(db, id, by.Value, ttl).ConfigureAwait(false);
         }
 
-        public static async Task<IResult> DecrAsync(IDatabaseService db, string id) =>
-            await IntegerMutationAsync(db, id, -1).ConfigureAwait(false);
+        public static async Task<IResult> DecrAsync(IDatabaseService db, string id, long? ttl = null) =>
+            await IntegerMutationAsync(db, id, -1, ttl).ConfigureAwait(false);
 
-        public static async Task<IResult> DecrByAsync(IDatabaseService db, string id, long? by)
+        public static async Task<IResult> DecrByAsync(IDatabaseService db, string id, long? by, long? ttl = null)
         {
             if (!by.HasValue)
                 return Results.BadRequest("Missing by.");
@@ -139,10 +139,10 @@ public static class DataSetRoutes
                 return Conflict("Integer decrement overflow.");
             }
 
-            return await IntegerMutationAsync(db, id, delta).ConfigureAwait(false);
+            return await IntegerMutationAsync(db, id, delta, ttl).ConfigureAwait(false);
         }
 
-        public static async Task<IResult> IncrByFloatAsync(IDatabaseService db, string id, decimal? by)
+        public static async Task<IResult> IncrByFloatAsync(IDatabaseService db, string id, decimal? by, long? ttl = null)
         {
             if (!by.HasValue)
                 return Results.BadRequest("Missing by.");
@@ -150,11 +150,15 @@ public static class DataSetRoutes
             if (!IdValidator.IsSafeId(id))
                 return Results.BadRequest("Invalid id.");
 
+            if (ttl.HasValue && ttl.Value <= 0)
+                return Results.BadRequest("Invalid ttl.");
+
             KeyValueCommandResult result;
             try
             {
                 result = await db.SetAsync(
                     DataKey(id),
+                    timeToLiveMilliseconds: ttl,
                     operation: KeyValueOperation.IncrementFloat,
                     floatDelta: by.Value).ConfigureAwait(false);
             }
@@ -174,16 +178,20 @@ public static class DataSetRoutes
             return ToNumericResult(result, isFloat: true);
         }
 
-        private static async Task<IResult> IntegerMutationAsync(IDatabaseService db, string id, long delta)
+        private static async Task<IResult> IntegerMutationAsync(IDatabaseService db, string id, long delta, long? ttl)
         {
             if (!IdValidator.IsSafeId(id))
                 return Results.BadRequest("Invalid id.");
+
+            if (ttl.HasValue && ttl.Value <= 0)
+                return Results.BadRequest("Invalid ttl.");
 
             KeyValueCommandResult result;
             try
             {
                 result = await db.SetAsync(
                     DataKey(id),
+                    timeToLiveMilliseconds: ttl,
                     operation: KeyValueOperation.IncrementInteger,
                     integerDelta: delta).ConfigureAwait(false);
             }

--- a/src/SlimFaas/Database/DatabaseMockService.cs
+++ b/src/SlimFaas/Database/DatabaseMockService.cs
@@ -10,7 +10,31 @@ public class DatabaseMockService : IDatabaseService
 {
     private readonly ConcurrentDictionary<string, IDictionary<string, byte[]>> hashSet = new();
     private readonly ConcurrentDictionary<string, byte[]> keys = new();
+    private readonly ConcurrentDictionary<string, long> expiresAt = new();
     private readonly ConcurrentDictionary<string, List<QueueData>> queue = new();
+
+    private static long? ToExpireAtUtcTicks(long? ttlMs)
+    {
+        if (!ttlMs.HasValue) return null;
+        var now = DateTime.UtcNow.Ticks;
+        if (ttlMs.Value <= 0) return now;
+        var add = ttlMs.Value * TimeSpan.TicksPerMillisecond;
+        var expire = now + add;
+        return expire < now ? long.MaxValue : expire;
+    }
+
+    private bool TryGetActiveValue(string key, out byte[] value)
+    {
+        value = Array.Empty<byte>();
+        if (expiresAt.TryGetValue(key, out var expireAt) && expireAt <= DateTime.UtcNow.Ticks)
+        {
+            keys.TryRemove(key, out _);
+            expiresAt.TryRemove(key, out _);
+            return false;
+        }
+
+        return keys.TryGetValue(key, out value!);
+    }
 
     public Task DeleteAsync(string key) => throw new NotImplementedException();
 
@@ -20,9 +44,9 @@ public class DatabaseMockService : IDatabaseService
     }
     public Task<byte[]?> GetAsync(string key)
     {
-        if (keys.TryGetValue(key, out byte[]? value))
+        if (TryGetActiveValue(key, out var value))
         {
-            return Task.FromResult(value)!;
+            return Task.FromResult<byte[]?>(value);
         }
 
         return Task.FromResult<byte[]?>(null);
@@ -31,17 +55,18 @@ public class DatabaseMockService : IDatabaseService
     public Task<KeyValueCommandResult> SetAsync(
         string key,
         byte[]? value = null,
-        long? timeToLiveSeconds = null,
+        long? timeToLiveMilliseconds = null,
         KeyValueOperation operation = KeyValueOperation.Set,
         long integerDelta = 0,
         decimal floatDelta = 0)
     {
         var result = new KeyValueCommandResult();
+        var expireAt = ToExpireAtUtcTicks(timeToLiveMilliseconds);
 
         if (operation == KeyValueOperation.IncrementInteger)
         {
             var current = 0L;
-            if (keys.TryGetValue(key, out var existing) &&
+            if (TryGetActiveValue(key, out var existing) &&
                 !long.TryParse(Encoding.UTF8.GetString(existing), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out current))
             {
                 result.SetError(KeyValueCommandStatus.InvalidNumber, "Value is not an integer.");
@@ -61,6 +86,8 @@ public class DatabaseMockService : IDatabaseService
 
             var bytes = Encoding.UTF8.GetBytes(next.ToString(CultureInfo.InvariantCulture));
             keys[key] = bytes;
+            if (expireAt.HasValue)
+                expiresAt[key] = expireAt.Value;
             result.SetApplied(bytes, integerValue: next);
             return Task.FromResult(result);
         }
@@ -68,7 +95,7 @@ public class DatabaseMockService : IDatabaseService
         if (operation == KeyValueOperation.IncrementFloat)
         {
             var current = 0m;
-            if (keys.TryGetValue(key, out var existing) &&
+            if (TryGetActiveValue(key, out var existing) &&
                 !decimal.TryParse(
                     Encoding.UTF8.GetString(existing),
                     NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent,
@@ -92,12 +119,18 @@ public class DatabaseMockService : IDatabaseService
 
             var bytes = Encoding.UTF8.GetBytes(next.ToString("G29", CultureInfo.InvariantCulture));
             keys[key] = bytes;
+            if (expireAt.HasValue)
+                expiresAt[key] = expireAt.Value;
             result.SetApplied(bytes, decimalValue: next);
             return Task.FromResult(result);
         }
 
         var setValue = value ?? Array.Empty<byte>();
         keys[key] = setValue;
+        if (expireAt.HasValue)
+            expiresAt[key] = expireAt.Value;
+        else
+            expiresAt.TryRemove(key, out _);
         result.SetApplied(setValue);
         return Task.FromResult(result);
     }

--- a/src/SlimFaas/Database/SlimDataService.cs
+++ b/src/SlimFaas/Database/SlimDataService.cs
@@ -306,7 +306,7 @@ public class SlimDataService
         decimal floatDelta)
     {
         var serializedValue = value ?? Array.Empty<byte>();
-        var expireAtUtcTicks = operation == KeyValueOperation.Set ? ToExpireAtUtcTicks(ttlMs) : null;
+        var expireAtUtcTicks = ToExpireAtUtcTicks(ttlMs);
 
         return await _batcher.EnqueueAsync<KeyValueReq, KeyValueCommandResult>(
             "kv",
@@ -330,7 +330,7 @@ public class SlimDataService
                     item.Operation,
                     item.Key,
                     item.SerializedValue,
-                    item.Operation == KeyValueOperation.Set ? item.ExpireAtUtcTicks : null,
+                    item.ExpireAtUtcTicks,
                     item.IntegerDelta,
                     item.FloatDelta,
                     item.NowTicks))

--- a/tests/SlimData.Tests/KeyValueCommandTests.cs
+++ b/tests/SlimData.Tests/KeyValueCommandTests.cs
@@ -67,21 +67,23 @@ public sealed class KeyValueCommandTests
             NowTicks = nowTicks > 0 ? nowTicks : DateTime.UtcNow.Ticks
         };
 
-    private static AddKeyValueCommand IncrementInteger(string key, long delta, long nowTicks = 0) =>
+    private static AddKeyValueCommand IncrementInteger(string key, long delta, long nowTicks = 0, long? expireAtUtcTicks = null) =>
         new()
         {
             Operation = KeyValueOperation.IncrementInteger,
             Key = key,
             IntegerDelta = delta,
+            ExpireAtUtcTicks = expireAtUtcTicks,
             NowTicks = nowTicks > 0 ? nowTicks : DateTime.UtcNow.Ticks
         };
 
-    private static AddKeyValueCommand IncrementFloat(string key, decimal delta, long nowTicks = 0) =>
+    private static AddKeyValueCommand IncrementFloat(string key, decimal delta, long nowTicks = 0, long? expireAtUtcTicks = null) =>
         new()
         {
             Operation = KeyValueOperation.IncrementFloat,
             Key = key,
             FloatDelta = delta,
+            ExpireAtUtcTicks = expireAtUtcTicks,
             NowTicks = nowTicks > 0 ? nowTicks : DateTime.UtcNow.Ticks
         };
 
@@ -170,6 +172,105 @@ public sealed class KeyValueCommandTests
 
         Assert.Equal(KeyValueCommandStatus.Overflow, result.Status);
         Assert.Equal(long.MaxValue.ToString(CultureInfo.InvariantCulture), Encoding.UTF8.GetString(state.KeyValues["counter"].Span));
+    }
+
+    [Fact]
+    public async Task Increment_integer_applies_ttl_when_provided_on_missing_key()
+    {
+        var state = NewState();
+        var ttl = DateTime.UtcNow.AddMinutes(5).Ticks;
+
+        var result = await ApplyAsync(state, IncrementInteger("counter", 1, expireAtUtcTicks: ttl));
+
+        Assert.Equal(KeyValueCommandStatus.Applied, result.Status);
+        Assert.Equal(1L, result.IntegerValue);
+        Assert.Equal("1", Encoding.UTF8.GetString(state.KeyValues["counter"].Span));
+        Assert.Equal(ttl, BitConverter.ToInt64(state.KeyValues[SlimDataInterpreter.TtlKey("counter")].Span));
+    }
+
+    [Fact]
+    public async Task Increment_integer_overrides_existing_ttl_when_provided()
+    {
+        var initialTtl = DateTime.UtcNow.AddMinutes(1).Ticks;
+        var newTtl = DateTime.UtcNow.AddHours(1).Ticks;
+        var state = NewState(ImmutableDictionary<string, ReadOnlyMemory<byte>>.Empty
+            .Add("counter", Encoding.UTF8.GetBytes("41"))
+            .Add(SlimDataInterpreter.TtlKey("counter"), BitConverter.GetBytes(initialTtl)));
+
+        var result = await ApplyAsync(state, IncrementInteger("counter", 1, expireAtUtcTicks: newTtl));
+
+        Assert.Equal(KeyValueCommandStatus.Applied, result.Status);
+        Assert.Equal(42L, result.IntegerValue);
+        Assert.Equal(newTtl, BitConverter.ToInt64(state.KeyValues[SlimDataInterpreter.TtlKey("counter")].Span));
+    }
+
+    [Fact]
+    public async Task Increment_integer_does_not_write_ttl_when_absent_and_no_previous_ttl()
+    {
+        var state = NewState(ImmutableDictionary<string, ReadOnlyMemory<byte>>.Empty
+            .Add("counter", Encoding.UTF8.GetBytes("10")));
+
+        var result = await ApplyAsync(state, IncrementInteger("counter", 1));
+
+        Assert.Equal(KeyValueCommandStatus.Applied, result.Status);
+        Assert.Equal(11L, result.IntegerValue);
+        Assert.False(state.KeyValues.ContainsKey(SlimDataInterpreter.TtlKey("counter")));
+    }
+
+    [Fact]
+    public async Task Increment_integer_does_not_write_ttl_on_invalid_number()
+    {
+        var newTtl = DateTime.UtcNow.AddHours(1).Ticks;
+        var state = NewState(ImmutableDictionary<string, ReadOnlyMemory<byte>>.Empty
+            .Add("counter", Encoding.UTF8.GetBytes("nope")));
+
+        var result = await ApplyAsync(state, IncrementInteger("counter", 1, expireAtUtcTicks: newTtl));
+
+        Assert.Equal(KeyValueCommandStatus.InvalidNumber, result.Status);
+        Assert.Equal("nope", Encoding.UTF8.GetString(state.KeyValues["counter"].Span));
+        Assert.False(state.KeyValues.ContainsKey(SlimDataInterpreter.TtlKey("counter")));
+    }
+
+    [Fact]
+    public async Task Increment_integer_does_not_write_ttl_on_overflow()
+    {
+        var newTtl = DateTime.UtcNow.AddHours(1).Ticks;
+        var state = NewState(ImmutableDictionary<string, ReadOnlyMemory<byte>>.Empty
+            .Add("counter", Encoding.UTF8.GetBytes(long.MaxValue.ToString(CultureInfo.InvariantCulture))));
+
+        var result = await ApplyAsync(state, IncrementInteger("counter", 1, expireAtUtcTicks: newTtl));
+
+        Assert.Equal(KeyValueCommandStatus.Overflow, result.Status);
+        Assert.False(state.KeyValues.ContainsKey(SlimDataInterpreter.TtlKey("counter")));
+    }
+
+    [Fact]
+    public async Task Increment_float_applies_ttl_when_provided()
+    {
+        var state = NewState(ImmutableDictionary<string, ReadOnlyMemory<byte>>.Empty
+            .Add("counter", Encoding.UTF8.GetBytes("1.25")));
+        var ttl = DateTime.UtcNow.AddMinutes(5).Ticks;
+
+        var result = await ApplyAsync(state, IncrementFloat("counter", 0.75m, expireAtUtcTicks: ttl));
+
+        Assert.Equal(KeyValueCommandStatus.Applied, result.Status);
+        Assert.Equal(2m, result.DecimalValue);
+        Assert.Equal(ttl, BitConverter.ToInt64(state.KeyValues[SlimDataInterpreter.TtlKey("counter")].Span));
+    }
+
+    [Fact]
+    public async Task Increment_float_preserves_existing_ttl_when_none_provided()
+    {
+        var ttl = DateTime.UtcNow.AddMinutes(1).Ticks;
+        var state = NewState(ImmutableDictionary<string, ReadOnlyMemory<byte>>.Empty
+            .Add("counter", Encoding.UTF8.GetBytes("1.25"))
+            .Add(SlimDataInterpreter.TtlKey("counter"), BitConverter.GetBytes(ttl)));
+
+        var result = await ApplyAsync(state, IncrementFloat("counter", 0.75m));
+
+        Assert.Equal(KeyValueCommandStatus.Applied, result.Status);
+        Assert.Equal(2m, result.DecimalValue);
+        Assert.Equal(ttl, BitConverter.ToInt64(state.KeyValues[SlimDataInterpreter.TtlKey("counter")].Span));
     }
 
     [Fact]

--- a/tests/SlimFaas.Tests/Data/DataSetRoutesTests.cs
+++ b/tests/SlimFaas.Tests/Data/DataSetRoutesTests.cs
@@ -231,6 +231,161 @@ public sealed class DataSetRoutesTests
 
 
     [Fact]
+    public async Task Incr_forwards_ttl_to_database()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+        db.Setup(d => d.SetAsync(
+                "data:set:counter",
+                (byte[]?)null,
+                60_000L,
+                KeyValueOperation.IncrementInteger,
+                1,
+                0m))
+          .ReturnsAsync(AppliedInteger(1));
+
+        var res = await DataSetRoutes.Handlers.IncrAsync(db.Object, "counter", 60_000L);
+
+        var text = Assert.IsType<ContentHttpResult>(res);
+        Assert.Equal("1", text.ResponseContent);
+        db.VerifyAll();
+    }
+
+    [Fact]
+    public async Task IncrBy_forwards_ttl_to_database()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+        db.Setup(d => d.SetAsync(
+                "data:set:counter",
+                (byte[]?)null,
+                30_000L,
+                KeyValueOperation.IncrementInteger,
+                5,
+                0m))
+          .ReturnsAsync(AppliedInteger(5));
+
+        var res = await DataSetRoutes.Handlers.IncrByAsync(db.Object, "counter", 5, 30_000L);
+
+        var text = Assert.IsType<ContentHttpResult>(res);
+        Assert.Equal("5", text.ResponseContent);
+        db.VerifyAll();
+    }
+
+    [Fact]
+    public async Task Decr_forwards_ttl_to_database()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+        db.Setup(d => d.SetAsync(
+                "data:set:counter",
+                (byte[]?)null,
+                15_000L,
+                KeyValueOperation.IncrementInteger,
+                -1,
+                0m))
+          .ReturnsAsync(AppliedInteger(-1));
+
+        var res = await DataSetRoutes.Handlers.DecrAsync(db.Object, "counter", 15_000L);
+
+        var text = Assert.IsType<ContentHttpResult>(res);
+        Assert.Equal("-1", text.ResponseContent);
+        db.VerifyAll();
+    }
+
+    [Fact]
+    public async Task DecrBy_forwards_ttl_to_database()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+        db.Setup(d => d.SetAsync(
+                "data:set:counter",
+                (byte[]?)null,
+                45_000L,
+                KeyValueOperation.IncrementInteger,
+                -3,
+                0m))
+          .ReturnsAsync(AppliedInteger(-3));
+
+        var res = await DataSetRoutes.Handlers.DecrByAsync(db.Object, "counter", 3, 45_000L);
+
+        var text = Assert.IsType<ContentHttpResult>(res);
+        Assert.Equal("-3", text.ResponseContent);
+        db.VerifyAll();
+    }
+
+    [Fact]
+    public async Task IncrByFloat_forwards_ttl_to_database()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+        db.Setup(d => d.SetAsync(
+                "data:set:counter",
+                (byte[]?)null,
+                90_000L,
+                KeyValueOperation.IncrementFloat,
+                0,
+                1.5m))
+          .ReturnsAsync(AppliedDecimal(1.5m));
+
+        var res = await DataSetRoutes.Handlers.IncrByFloatAsync(db.Object, "counter", 1.5m, 90_000L);
+
+        var text = Assert.IsType<ContentHttpResult>(res);
+        Assert.Equal("1.5", text.ResponseContent);
+        db.VerifyAll();
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public async Task Incr_rejects_invalid_ttl(long ttl)
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+
+        var res = await DataSetRoutes.Handlers.IncrAsync(db.Object, "counter", ttl);
+
+        Assert.IsType<BadRequest<string>>(res);
+        db.VerifyAll(); // no call expected
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-10L)]
+    public async Task IncrBy_rejects_invalid_ttl(long ttl)
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+
+        var res = await DataSetRoutes.Handlers.IncrByAsync(db.Object, "counter", 1, ttl);
+
+        Assert.IsType<BadRequest<string>>(res);
+    }
+
+    [Fact]
+    public async Task Decr_rejects_invalid_ttl()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+
+        var res = await DataSetRoutes.Handlers.DecrAsync(db.Object, "counter", -1L);
+
+        Assert.IsType<BadRequest<string>>(res);
+    }
+
+    [Fact]
+    public async Task DecrBy_rejects_invalid_ttl()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+
+        var res = await DataSetRoutes.Handlers.DecrByAsync(db.Object, "counter", 1, 0L);
+
+        Assert.IsType<BadRequest<string>>(res);
+    }
+
+    [Fact]
+    public async Task IncrByFloat_rejects_invalid_ttl()
+    {
+        var db = new Mock<IDatabaseService>(MockBehavior.Strict);
+
+        var res = await DataSetRoutes.Handlers.IncrByFloatAsync(db.Object, "counter", 1m, -5L);
+
+        Assert.IsType<BadRequest<string>>(res);
+    }
+
+    [Fact]
     public async Task Delete_deletes_key()
     {
         var db = new Mock<IDatabaseService>(MockBehavior.Strict);


### PR DESCRIPTION
Fixes #293

## Summary
This PR implements the fix for Issue #293: ttl must work with sets incr command.

## Problem synthesis
Implement TTL support for set mutation endpoints that atomically increment/decrement values: `/data/sets/{id}/incr`, `/incrby`, `/incrbyfloat`, `/decr`, and `/decrby`. These commands currently appear to ignore or lack TTL handling, but should preserve/apply TTL behavior consistently with other set operations.

## Approach
### Root cause
1. Routes (`src/SlimFaas/Data/DataSetRoutes.cs`): `IncrAsync`, `IncrByAsync`, `IncrByFloatAsync`, `DecrAsync`, `DecrByAsync` have no `long? ttl` parameter and never forward one to `IDatabaseService.SetAsync`.
2. Service (`src/SlimFaas/Database/SlimDataService.cs`): TTL is explicitly forced to `null` for every non-`Set` operation.
3. Interpreter (`src/SlimData/SlimDataInterpreter.cs`, `DoIncrementInteger` / `DoIncrementFloat`): only writes the value key; never writes/updates the TTL key. This preserves an existing TTL by construction, but cannot apply a new one.

### Target semantics
- Add optional `ttl` query parameter, in milliseconds, to all five counter endpoints: `incr`, `incrby`, `incrbyfloat`, `decr`, and `decrby`.
- If `ttl` is omitted, preserve any existing live TTL; if there is no TTL or the key is missing/expired, do not set one.
- If `ttl > 0` is provided, apply/override the TTL on the value key.
- If `ttl <= 0` or invalid, return `400 Bad Request`.
- Overflow or invalid-number errors should still return `409 Conflict` without mutating value or TTL.

### Implementation plan
1. Update the five route handlers in `DataSetRoutes.cs` to accept `long? ttl` and pass it to `db.SetAsync` as `timeToLiveMilliseconds`.
2. Validate `ttl` consistently in integer and float mutation paths: reject `ttl <= 0` with `400 Bad Request`.
3. Update `SlimDataService.DoSetAsync` and batch handling so `ExpireAtUtcTicks` is not dropped for non-`Set` operations.
4. Update `SlimDataInterpreter.DoIncrementInteger` and `DoIncrementFloat` so that when `ExpireAtUtcTicks` is provided, the TTL sibling key is written/updated. If no TTL is provided, leave the existing TTL untouched.
5. Keep non-idempotent numeric mutations non-retried.
6. Update `DatabaseMockService` to mirror TTL behavior for increment/decrement operations.
7. Add tests for TTL application, TTL preservation, TTL override, invalid TTL, expired keys, overflow/non-numeric conflicts, and listing/filtering behavior.
8. Update `documentation/data-sets.md` to include the new `ttl` query parameter and explain preservation/override semantics.

## Changes
- Implemented the fix using GitHub Copilot Agent (anthropic provider).
- Added or updated unit tests covering the new behavior.

## Checks performed
- Project compiles.
- Unit tests updated/added and executed.
- Change scope limited to this Issue only.
