### PR TITLE
fix(slimdata): make key-value reads linearizable (release)

### DIFF
--- a/docs/data-files.md
+++ b/docs/data-files.md
@@ -95,10 +95,14 @@ curl -X POST "http://<slimfaas>/data/files?id=my-artifact-001&ttl=300000"   -H "
 
 When you request an artifact:
 
-1. SlimFaas reads the **cluster-consistent metadata** for `{id}` (checksum, size, content type, filename, TTL)
+1. SlimFaas applies a Raft read barrier and reads the **cluster-consistent metadata** for `{id}` (checksum, size, content type, filename, TTL)
 2. It checks whether the binary exists locally and matches the expected checksum
 3. If missing, SlimFaas attempts to **pull** the binary from another cluster node that has it
 4. The response streams the binary to the client
+
+After a create or overwrite returns `200 OK`, a later download through any
+healthy cluster node uses the latest committed metadata. A follower waits until
+that metadata is applied locally instead of serving an older checksum.
 
 ### Responses
 
@@ -107,6 +111,7 @@ When you request an artifact:
     - a download filename if provided at upload time
 - `400 Bad Request` if id is invalid
 - `404 Not Found` if metadata is missing/expired, or if no node can provide the binary
+- `503 Service Unavailable` if the Raft quorum cannot guarantee a current metadata read
 
 ### Example (curl)
 
@@ -216,6 +221,10 @@ For `/data/files`:
 - **binary content** is stored on disk on the node that received the POST request
 
 This avoids moving large binaries through the cluster’s consensus layer.
+Metadata reads are linearizable: followers synchronize to the leader's current
+commit index before selecting the checksum to serve. Binary distribution remains
+eventual; an on-demand pull supplies the committed version when it is not yet
+present on the node handling the download.
 
 ### 2) Cluster distribution model: announce + pull
 

--- a/docs/data-sets.md
+++ b/docs/data-sets.md
@@ -170,6 +170,12 @@ curl -s "http://<slimfaas>/data/sets/request-count"
 
 - Returns raw bytes as `application/octet-stream`.
 - `404 Not Found` when missing or expired.
+- `503 Service Unavailable` when the Raft quorum cannot guarantee a current read.
+
+Reads are linearizable. After a create or overwrite returns successfully, a
+later `GET` through any healthy cluster node observes that committed value. A
+follower applies a Raft read barrier and catches up to the leader's commit index
+before reading its local state.
 
 Examples:
 ```bash
@@ -233,11 +239,11 @@ Env override:
 
 ## Availability and backpressure
 
-Writes are grouped into bounded adaptive batches before being replicated as Raft entries. The API can return:
+Writes are grouped into bounded adaptive batches before being replicated as Raft entries. Key/value reads use a bounded Raft read barrier. The API can return:
 
 - **413 Payload Too Large** when one item exceeds the configured batch limit.
 - **429 Too Many Requests** when the in-memory adaptive batch queue is full.
-- **503 Service Unavailable** when no Raft quorum or valid leader lease is available within the bounded replication timeout.
+- **503 Service Unavailable** when no Raft quorum or valid leader lease is available within the bounded replication or read-barrier timeout.
 
 `SET` keeps its existing retry behavior. Numeric mutations are not retried automatically because they are not idempotent.
 

--- a/src/SlimFaas/Database/SlimDataService.cs
+++ b/src/SlimFaas/Database/SlimDataService.cs
@@ -21,6 +21,7 @@ public sealed class SlimDataService : IDatabaseService, IAsyncDisposable
     private const string UnifiedBatchKind = "commands";
     private const string UnifiedBatchResource = "SlimData/CommandBatch";
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan ReadBarrierTimeout = TimeSpan.FromSeconds(5);
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IServiceProvider _serviceProvider;
@@ -475,9 +476,29 @@ public sealed class SlimDataService : IDatabaseService, IAsyncDisposable
 
     private async Task<byte[]?> DoGetAsync(string key)
     {
-        await GetAndWaitForLeader().ConfigureAwait(false);
-        await WaitForLocalApplyAsync().ConfigureAwait(false);
-        await MasterWaitForLeaseToken().ConfigureAwait(false);
+        using var timeout = new CancellationTokenSource(ReadBarrierTimeout);
+        try
+        {
+            await GetAndWaitForLeader(timeout.Token).ConfigureAwait(false);
+
+            // On a follower, the read barrier asks the leader for its current
+            // commit index and waits until that index is applied locally.
+            // Weak avoids forcing unrelated pending writes on the leader; a
+            // completed SetAsync is already committed before it returns.
+            await _cluster.ApplyReadBarrierAsync(ReadBarrierType.Weak, timeout.Token)
+                .ConfigureAwait(false);
+            await MasterWaitForLeaseToken(timeout.Token).ConfigureAwait(false);
+        }
+        catch (QuorumUnreachableException ex)
+        {
+            throw new SlimDataUnavailableException(
+                "Raft quorum is unavailable for a linearizable read.", ex);
+        }
+        catch (OperationCanceledException ex) when (timeout.IsCancellationRequested)
+        {
+            throw new SlimDataUnavailableException(
+                "Raft read barrier or leader lease timed out.", ex);
+        }
 
         var data = SimplePersistentState.Invoke();
         if (TryReadExpireAtFromKeyValues(data, key, out var expireAt) &&

--- a/tests/SlimData.Tests/RaftClusterTests.cs
+++ b/tests/SlimData.Tests/RaftClusterTests.cs
@@ -278,6 +278,28 @@ public class RaftClusterTests
         await GetLocalClusterView(host3).Readiness.WaitAsync(BusyMembershipCatchUpTimeout);
         await GetLocalClusterView(host1).ForceReplicationAsync();
 
+        IDatabaseService[] readServices =
+        [
+            databaseServiceMaster,
+            host2.Services.GetRequiredService<IDatabaseService>(),
+            host3.Services.GetRequiredService<IDatabaseService>()
+        ];
+
+        const int readAfterWriteIterations = 16;
+        for (var i = 0; i < readAfterWriteIterations; i++)
+        {
+            var expected = $"version-{i:D2}";
+            await databaseServiceMaster.SetAsync(
+                "read-after-write",
+                Encoding.UTF8.GetBytes(expected));
+
+            foreach (IDatabaseService readService in readServices)
+            {
+                var actual = await readService.GetAsync("read-after-write");
+                Assert.Equal(expected, Encoding.UTF8.GetString(actual ?? []));
+            }
+        }
+
         IDatabaseService databaseServiceSlave = host3.Services.GetRequiredService<IDatabaseService>();
         var thirdMemberEndpoint = GetLocalClusterView(host3).LocalMemberAddress;
         Assert.True(await membershipCoordinator.RemoveMemberAsync(


### PR DESCRIPTION
## Summary

- apply the DotNext weak Raft read barrier before shared key/value reads
- bound leader, read-barrier, and lease waits to five seconds and surface unavailable consistency as HTTP 503
- keep queue reads on their existing optimized path
- document read-after-write behavior for Data Files and Data Sets

## Root cause

`SlimDataService.GetAsync` waited only for the commit index already known by the local node. A follower could therefore read its local snapshot before learning about a write that had completed successfully on the leader.

Before the fix, a three-node native-local reproduction observed:

- `/data/files`: 3,948 incorrect responses across 5,997 immediate reads, including two stale files returned with HTTP 200
- `/data/sets`: 1,978 stale or missing responses across 3,000 immediate reads

The weak read barrier asks the leader for its current commit index and waits for that index to be applied locally. Existing quorum and leader-lease checks remain in place. Timeouts or an unreachable quorum raise `SlimDataUnavailableException`, which the API maps to HTTP 503.

Binary file distribution is unchanged and remains announce + pull; only the Raft-backed metadata read is linearizable.

## Validation

- `dotnet test --no-restore --verbosity minimal`: 1,141 passed
- `dotnet test tests/SlimData.Tests/SlimData.Tests.csproj --no-restore --filter FullyQualifiedName~SlimData.Tests.RaftClusterTests.MessageExchange`: passed
- `dotnet test tests/SlimFaas.Tests/SlimFaas.Tests.csproj --no-restore --filter FullyQualifiedName~DataFileRoutesTests`: 15 passed
- backend build with `SkipClientAppBuild=true`: passed
- native AOT publish for `osx-arm64` plus `local validate`: passed
- documentation site production build: passed
- three-node stress after the fix:
  - `/data/files`: 1,000 overwrites, 3,000 immediate node-specific reads, zero stale values and zero 404 responses
  - `/data/sets`: 1,000 overwrites, 3,000 immediate node-specific reads, zero stale values and zero 404 responses
- targeted SlimData benchmark candidate:
  - mixed C12: 996 operations, zero request errors, zero validation failures
  - mixed C48: 13,104 operations, zero request errors, zero validation failures
  - the A/B script itself returned FAIL because the older stored baseline lacks the hashset routes and produced 977 request errors plus 51 consistency-validation failures; its comparison verdict is therefore not a valid regression signal for this isolated change

Fixes #328