### PR TITLE
feat: support external OpenMetrics autoscaling sources

### DIFF
--- a/.bin/slimfaas-local-external-metrics-test.sh
+++ b/.bin/slimfaas-local-external-metrics-test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+run_root="${EXTERNAL_METRICS_TEST_RUN_ROOT:-$repo_root/artifacts/slimfaas-local-external-metrics/$timestamp}"
+manifest="$repo_root/benchmarks/slimfaas.local.external-metrics.yaml"
+slimfaas_project="$repo_root/src/SlimFaas/SlimFaas.csproj"
+benchmark_project="$repo_root/src/SlimFaasBenchmark/SlimFaasBenchmark.csproj"
+slimfaas_dll="$repo_root/src/SlimFaas/bin/Release/net10.0/SlimFaas.dll"
+local_log="$run_root/slimfaas-local.log"
+entrypoint="http://127.0.0.1:31120"
+exporter="http://127.0.0.1:31180"
+function_name="benchmark-external-scale"
+local_pid=""
+
+mkdir -p "$run_root"
+
+cleanup() {
+  local exit_code=$?
+  if [[ -n "$local_pid" ]] && kill -0 "$local_pid" 2>/dev/null; then
+    kill -TERM "$local_pid" 2>/dev/null || true
+    for _ in $(seq 1 100); do
+      if ! kill -0 "$local_pid" 2>/dev/null; then
+        break
+      fi
+      sleep 0.1
+    done
+    if kill -0 "$local_pid" 2>/dev/null; then
+      kill -KILL "$local_pid" 2>/dev/null || true
+    fi
+    wait "$local_pid" 2>/dev/null || true
+  fi
+  if [[ "$exit_code" -ne 0 ]]; then
+    echo "External metrics integration test failed. Logs are preserved in $run_root" >&2
+    tail -n 100 "$local_log" >&2 2>/dev/null || true
+  fi
+  return "$exit_code"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+wait_for_http() {
+  local url="$1"
+  local description="$2"
+  for attempt in $(seq 1 120); do
+    if [[ -n "$local_pid" ]] && ! kill -0 "$local_pid" 2>/dev/null; then
+      echo "slimfaas local exited while waiting for $description" >&2
+      return 1
+    fi
+    if curl --silent --fail "$url" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for $description" >&2
+  return 1
+}
+
+wait_for_scale() {
+  local expected="$1"
+  local status=""
+  for _ in $(seq 1 120); do
+    status="$(curl --silent --fail "$entrypoint/status-function/$function_name" 2>/dev/null || true)"
+    if [[ "$status" == *"\"NumberRequested\":$expected"* &&
+          "$status" == *"\"NumberReady\":$expected"* ]]; then
+      echo "Validated scale target $expected: $status"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for requested/ready replicas=$expected. Last status: $status" >&2
+  return 1
+}
+
+if [[ "${EXTERNAL_METRICS_TEST_SKIP_BUILD:-false}" != "true" ]]; then
+  echo "Building SlimFaas and the controllable OpenMetrics exporter"
+  dotnet build "$slimfaas_project" -c Release -p:SkipClientAppBuild=true --nologo
+  dotnet build "$benchmark_project" -c Release --nologo
+fi
+
+dotnet "$slimfaas_dll" local validate -f "$manifest"
+
+echo "Starting slimfaas local external metrics scenario"
+(
+  cd "$repo_root"
+  exec dotnet "$slimfaas_dll" local up -f "$manifest" --clean
+) >"$local_log" 2>&1 &
+local_pid="$!"
+
+wait_for_http "$entrypoint/ready" "SlimFaas readiness"
+wait_for_http "$exporter/health" "external exporter readiness"
+wait_for_scale 0
+
+for expected in 2 4 0; do
+  curl --silent --fail --request PUT "$exporter/benchmark/external-pressure/$expected" >/dev/null
+  wait_for_scale "$expected"
+done
+
+echo "External OpenMetrics autoscaling integration test passed (0 -> 2 -> 4 -> 0)."
+echo "Logs: $run_root"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It’s designed to be **fast**, **simple**, and **extremely slim** — with a ve
 - **Two-phase scaling model**
     - **`0 → N`**: driven by HTTP history, schedules, **and Kafka lag (SlimFaas Kafka)** to bring functions online only when they’re needed.
     - **`N → M`**: driven by a built-in PromQL mini-evaluator on top of an internal metrics store.
-    - Metrics-based autoscaling only runs when at least one pod exists — no reliance on non-existent metrics.
+    - Named external OpenMetrics sources can drive both **`0 → N`** and **`N → M`**, independently of function pods.
 
 - **PromQL-driven autoscaler**
     - Express scaling rules with PromQL-style queries, for example:
@@ -75,7 +75,7 @@ It’s designed to be **fast**, **simple**, and **extremely slim** — with a ve
     - Configure scale-up/scale-down policies and stabilization windows inspired by HPA/KEDA.
 
 - **Integrated metrics scraping**
-    - SlimFaas scrapes only the Prometheus-style HTTP metrics endpoints of pods with `prometheus.io/scrape: "true"`.
+    - SlimFaas scrapes pod endpoints with `prometheus.io/scrape: "true"` and named HTTP/HTTPS OpenMetrics sources configured per function.
     - It stores only the **metric keys that are requested** in autoscaling triggers or debug queries.
     - A single designated node scrapes and persists metrics; all other nodes read from the same store.
 

--- a/benchmarks/slimfaas.local.external-metrics.yaml
+++ b/benchmarks/slimfaas.local.external-metrics.yaml
@@ -1,0 +1,78 @@
+schemaVersion: 1
+name: slimfaas-external-metrics
+
+cluster:
+  nodes: 1
+  entrypointPort: 31120
+  nodeHttpPortBase: 31121
+  raftPortBase: 3172
+  nodeLogLevel: Information
+
+processPorts:
+  from: 32100
+  to: 32110
+
+state:
+  mode: ephemeral
+
+functions:
+  benchmark-external-scale:
+    command:
+      - dotnet
+      - src/SlimFaasBenchmark/bin/Release/net10.0/SlimFaasBenchmark.dll
+      - target
+    workingDirectory: ..
+    annotations:
+      SlimFaas/Function: "true"
+      SlimFaas/TimeoutSecondBeforeSetReplicasMin: "0"
+      SlimFaas/ReplicasAtStart: "1"
+      SlimFaas/ReplicasMin: "0"
+      SlimFaas/Scale: >
+        {
+          "ReplicaMax": 4,
+          "ScrapeIntervalMilliseconds": 1000,
+          "Sources": [
+            {
+              "Name": "benchmark-exporter",
+              "Url": "http://127.0.0.1:31180/metrics"
+            }
+          ],
+          "Triggers": [
+            {
+              "MetricType": "AverageValue",
+              "MetricName": "external_pressure",
+              "Query": "slimfaas_benchmark_external_pressure",
+              "Threshold": 1,
+              "Source": "benchmark-exporter"
+            }
+          ],
+          "Behavior": {
+            "ScaleUp": {
+              "StabilizationWindowSeconds": 0,
+              "Policies": []
+            },
+            "ScaleDown": {
+              "StabilizationWindowSeconds": 0,
+              "Policies": []
+            }
+          }
+        }
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: "http://127.0.0.1:{port}"
+    health:
+      path: /health
+      periodSeconds: 1
+      timeoutSeconds: 2
+      startupTimeoutSeconds: 120
+
+processes:
+  benchmark-exporter:
+    command:
+      - dotnet
+      - src/SlimFaasBenchmark/bin/Release/net10.0/SlimFaasBenchmark.dll
+      - target
+      - --port
+      - "31180"
+    workingDirectory: ..
+    restartPolicy: always

--- a/demo/deployment-functions.yml
+++ b/demo/deployment-functions.yml
@@ -26,16 +26,23 @@ spec:
         prometheus.io/port: "5000"
         prometheus.io/scrape: "true"
 
-        # N -> M (AutoScaler Prometheus)
+        # 0 -> N and N -> M from the always-on SlimFaas queue metrics endpoint
         SlimFaas/Scale: >
           {
             "ReplicaMax": 10,
+            "Sources": [
+              {
+                "Name": "slimfaas",
+                "Url": "http://slimfaas.slimfaas-demo.svc.cluster.local:5000/metrics"
+              }
+            ],
             "Triggers": [
               {
-                "MetricType": "Value",
+                "MetricType": "AverageValue",
                 "MetricName": "max_over_time_queue_fibonacci1",
                 "Query": "max_over_time(slimfaas_function_queue_ready_items{function=\"fibonacci1\"}[30s])",
-                "Threshold": 10
+                "Threshold": 10,
+                "Source": "slimfaas"
               }
             ],
             "Behavior": {

--- a/demo/deployment-kafka.yml
+++ b/demo/deployment-kafka.yml
@@ -185,6 +185,20 @@ spec:
               memory: "64Mi"
               cpu: "20m"
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: slimfaas-kafka
+  namespace: slimfaas-demo
+spec:
+  selector:
+    app: slimfaas-kafka
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  type: ClusterIP
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -272,4 +286,3 @@ spec:
             requests:
               memory: "64Mi"
               cpu: "10m"
-

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -1,7 +1,7 @@
 # SlimFaas Autoscaling Guide
 
 > End-to-end autoscaling for SlimFaas functions:
-> **HTTP activity & schedules for `0 → N` + Prometheus / PromQL AutoScaler for `N → M`**
+> **HTTP activity, schedules, and external OpenMetrics sources for `0 → N`, plus PromQL autoscaling for `N → M`**
 
 ---
 
@@ -11,7 +11,7 @@
 2. [Core concepts](#core-concepts)
 3. [Autoscaling architecture](#autoscaling-architecture)
 4. [Configuring `0 → N` scale (HTTP history + schedule)](#configuring-0--n-scale-http-history--schedule)
-5. [Configuring `N → M` scale (Prometheus AutoScaler)](#configuring-n--m-scale-prometheus-autoscaler)
+5. [Configuring metrics-based scaling](#configuring-metrics-based-scaling)
 6. [PromQL support & current limitations](#promql-support--current-limitations)
 7. [Metrics scraping internals](#metrics-scraping-internals)
 8. [Debug HTTP endpoints](#debug-http-endpoints)
@@ -33,15 +33,17 @@ SlimFaas combines **two complementary autoscaling systems**:
     - optional **schedule configuration** (wake-up times, scale-down timeouts),
     - **function dependencies** (`DependsOn`).
 
-   👉 This system is the **only one allowed to bring a function from `0` to `> 0` replicas**.
+   Named external OpenMetrics triggers can also wake a function without HTTP activity.
 
-2. **`N → M` scaling (Prometheus AutoScaler)**
+2. **Metrics-based scaling (PromQL AutoScaler)**
    Driven by:
     - a Prometheus metrics scraping worker,
     - a small PromQL evaluator,
     - an `AutoScaler` that computes the desired number of replicas based on metrics.
 
-   👉 This system is used **only when the function already has at least one pod** (`replicas > 0`).
+   Pod-local triggers adjust existing capacity. Triggers attached to a named external
+   source can also scale from zero because the source remains available independently
+   from the function pods.
 
 When the Prometheus-based AutoScaler is enabled for a function (`SlimFaas/Scale` has at least one trigger), **scale-to-zero is allowed only if both systems agree**: the HTTP/schedule logic must decide that the function can go down to `ReplicasMin = 0`, *and* the metrics-based AutoScaler must also compute a desired replica count of `0`. If metrics still indicate that capacity is needed (`desired > 0`), SlimFaas keeps at least one replica running even if HTTP activity is idle. An empty `Triggers` list disables this metric veto.
 
@@ -81,7 +83,8 @@ For each function (deployment):
     - **time-dependent scale-down timeouts**.
 
 - **`Scale`**
-  Metrics-based autoscaling configuration, powered by Prometheus & PromQL, used for `N → M` scaling.
+  Metrics-based autoscaling configuration, powered by OpenMetrics and PromQL. Pod-local
+  triggers drive `N → M`; external-source triggers can also drive `0 → N`.
 
 ### How this is exposed in Kubernetes
 
@@ -140,7 +143,8 @@ flowchart LR
     DP[DependsOn] --> R
   end
 
-  subgraph Prometheus["Prometheus AutoScaler (N->M)"]
+  subgraph Prometheus["OpenMetrics / PromQL AutoScaler"]
+    ES[External sources] --> MSW
     MSW[MetricsScrapingWorker] --> MS[Metrics store]
     MS --> PQ[PromQL evaluator]
     PQ --> AS[AutoScaler]
@@ -156,7 +160,8 @@ flowchart LR
 - `ScaleReplicasWorker` periodically calls `CheckScaleAsync` if the node is the master.
 - `ReplicasService.CheckScaleAsync`:
     1. Computes a **desired replica count** using the **HTTP/schedule based system** (`0 → N` / `N → 0`).
-    2. If the function already has `replicas > 0` and at least one `SlimFaas/Scale` trigger, it invokes the **Prometheus AutoScaler** to adjust `N → M` and, when `ReplicasMin = 0`, to confirm whether scale-to-zero is actually allowed.
+    2. Invokes the PromQL AutoScaler when the function has replicas, or at zero when
+       at least one trigger uses an external source. Local pod triggers are ignored at zero.
 
 ---
 
@@ -216,10 +221,9 @@ There are two main situations where SlimFaas wakes a function up:
     - Dependencies are ready.
     - ⇒ SlimFaas scales the function up to `ReplicasAtStart`.
 
-This ensures:
-
-- **Only the `0 → N` system can wake a function from 0**,
-- The function will start with a known initial capacity before the Prometheus AutoScaler adjusts it.
+This ensures HTTP and schedules still start a function at `ReplicasAtStart`. An
+external metrics trigger may instead calculate the initial capacity directly from
+its signal, subject to `ReplicaMax`, policies, and stabilization.
 
 ### Time-based schedule (wake-up & scale-down timeout)
 
@@ -259,9 +263,12 @@ This allows you, for example:
 
 ---
 
-## Configuring `N → M` scale (Prometheus AutoScaler)
+## Configuring metrics-based scaling
 
-The Prometheus-based AutoScaler is activated by adding a `SlimFaas/Scale` annotation on the function’s Deployment. It **only runs when the function has at least one pod**.
+The PromQL AutoScaler is activated by adding a `SlimFaas/Scale` annotation on the
+function's Deployment. A trigger without `Source` reads the function pods and only
+runs while pods exist. A trigger with `Source` reads a named external endpoint and
+can run while the function has zero replicas.
 
 ### `SlimFaas/Scale` annotation structure (JSON)
 
@@ -274,12 +281,19 @@ metadata:
       {
         "ReplicaMax": 20,
         "ScrapeIntervalMilliseconds": 1000,
+        "Sources": [
+          {
+            "Name": "queue-exporter",
+            "Url": "https://queue-metrics.example.internal/metrics?tenant=orders"
+          }
+        ],
         "Triggers": [
           {
             "MetricType": "AverageValue",
-            "MetricName": "rps_per_pod",
-            "Query": "sum(rate(http_server_requests_seconds_count{namespace=\"${namespace}\",job=\"${app}\"}[1m]))",
-            "Threshold": 50
+            "MetricName": "pending_orders",
+            "Query": "orders_pending",
+            "Threshold": 50,
+            "Source": "queue-exporter"
           }
         ],
         "Behavior": {
@@ -322,6 +336,15 @@ Main fields:
     - `MetricName`: human-readable metric name (for doc / logs).
     - `Query`: PromQL query that **must return a scalar** (single numeric value).
     - `Threshold`: target value for the metric (per pod or total, depending on `MetricType`).
+    - `Source` (optional): case-sensitive name from `Sources`. If omitted, the
+      trigger retains the historical behavior and reads metrics from the function pods.
+
+- `Sources`
+  Named external OpenMetrics endpoints. Names must be unique within a function.
+  URLs must be absolute HTTP/HTTPS URLs without embedded credentials or fragments;
+  query parameters are accepted but are never included in logs or metric labels.
+  Only sources referenced by a trigger are scraped, once per scrape cycle even when
+  several triggers use the same source.
 
 - `Behavior`
   Configuration of scale-up / scale-down behavior:
@@ -359,6 +382,16 @@ When `ReplicasMin` is `0` and a `SlimFaas/Scale` configuration has at least one 
     - If it computes `desiredReplicas > 0`, SlimFaas keeps **at least one replica** running (or more, according to `desiredReplicas`), even if HTTP activity is idle.
 
 This provides an extra safety net against scaling to zero when metrics show that work may still be pending (for example due to queue length, high latency, etc.).
+
+An external trigger is also evaluated while the function is at zero. It can therefore
+wake the function directly to the calculated replica count. Local pod triggers are
+ignored at zero so samples left in the store cannot wake a function after its last pod
+has stopped.
+
+External-source health is deliberately fail-safe. A failed or timed-out scrape, an
+invalid response, a referenced metric missing or non-finite in the latest scrape, or
+data older than three scrape intervals makes that trigger invalid immediately. An
+invalid trigger blocks scale-down, while another valid trigger may still scale up.
 
 ### Policies and stabilization
 
@@ -671,7 +704,8 @@ scraping and storage pipeline that is optimized for autoscaling signals.
 
 At a high level:
 
-- Only the **metrics HTTP endpoint** is called on your pods.
+- The **metrics HTTP endpoint** is called on annotated pods and on external sources
+  referenced by triggers.
 - SlimFaas keeps in memory **only the metric keys that have been requested at least once**.
 - A single SlimFaas node is responsible for scraping and persisting metrics.
 - All nodes evaluate PromQL against a **shared, synchronized store** with a **30-minute retention window**.
@@ -682,12 +716,13 @@ At a high level:
 
 ### Scraping cycle (every 5 seconds)
 
-Every 5 seconds, a background worker (`MetricsScrapingWorker`) runs on the
-**designated scraping node** and performs the following steps:
+At the configured cadence, a background worker (`MetricsScrapingWorker`) runs on the
+master node and performs the following steps:
 
-1. Discover pods that:
+1. Discover targets that are either:
     - are part of your SlimFaas workloads, and
-    - expose Prometheus-compatible HTTP metrics via annotations.
+      expose Prometheus-compatible HTTP metrics via annotations, or
+    - named external sources referenced by at least one trigger.
 
 2. For each pod that has Prometheus HTTP annotations (for example):
 
@@ -701,6 +736,11 @@ Every 5 seconds, a background worker (`MetricsScrapingWorker`) runs on the
    ```text
    <scheme>://<pod-ip>:<port><path>
    ```
+
+   External source URLs come directly from `Scale.Sources`. They use the same HTTP
+   client timeout, response-size and parser limits as pod targets. Metrics are stored
+   in an isolated scope for each function/source pair, so identical metric names from
+   local pods or another source cannot mix.
 
 3. It sends a **single HTTP GET** to the metrics endpoint of each such pod and
    parses the standard Prometheus exposition format:
@@ -724,7 +764,10 @@ SlimFaas exposes the scaler state through `slimfaas_autoscaler_trigger_value`,
 `slimfaas_autoscaler_desired_replicas`, `slimfaas_autoscaler_ready_replicas` and
 `slimfaas_autoscaler_last_decision`. Scrape health is available through
 `slimfaas_metrics_scrape_duration_seconds`, `slimfaas_metrics_scrape_failures_total`
-and `slimfaas_metrics_scrape_last_success_unixtime`. Queries are never used as labels.
+and `slimfaas_metrics_scrape_last_success_unixtime`. The bounded `source` label is
+`pods` for local targets or the configured source name, and
+`slimfaas_metrics_source_available` reports the latest scrape availability. URLs and
+queries are never used as labels.
 
 ---
 
@@ -757,7 +800,8 @@ for example:
 
 ```bash
 curl -X POST "http://localhost:5000/debug/promql/eval"   -H "Content-Type: application/json"   -d '{
-    "query": "max_over_time(some_new_metric{function=\"fibonacci\"}[30s])"
+    "query": "max_over_time(some_new_metric{function=\"fibonacci\"}[30s])",
+    "deployment": "fibonacci"
   }'
 ```
 
@@ -772,7 +816,7 @@ becomes requested.
 
 ---
 
-### Scraping node, master node, and database synchronization
+### Master scraping and database synchronization
 
 In a SlimFaas cluster there are two important roles:
 
@@ -782,7 +826,7 @@ In a SlimFaas cluster there are two important roles:
     - runs `ScaleReplicasWorker`,
     - applies scaling changes to Kubernetes.
 
-- The **designated scraping node** (not the master)
+- The **master node** also owns metrics ingestion:
   Responsible for metrics ingestion:
     - runs `MetricsScrapingWorker`,
     - calls the metrics endpoints on your pods every 5 seconds,
@@ -790,7 +834,7 @@ In a SlimFaas cluster there are two important roles:
     - periodically serializes the metrics store to the SlimFaas database
       (for example under the key `metrics:store`).
 
-All **other** SlimFaas nodes, including the master, do **not** scrape your pods.
+All **other** SlimFaas nodes do **not** scrape targets.
 Instead, they:
 
 1. Periodically read the serialized metrics store from the SlimFaas database.
@@ -866,7 +910,8 @@ This endpoint also:
 {
   "query": "max_over_time(slimfaas_function_queue_ready_items{function=\"fibonacci\"}[30s])",
   "nowUnixSeconds": 1732100000,
-  "deployment": "fibonacci"
+  "deployment": "fibonacci",
+  "source": "slimfaas"
 }
 ```
 
@@ -875,8 +920,10 @@ Fields:
 - `query` (required): the PromQL expression to evaluate.
 - `nowUnixSeconds` (optional): Unix timestamp (seconds) to use as “now” for range selectors.
   If omitted, the evaluator uses the **latest timestamp available in the store**.
-- `deployment` (optional): restricts evaluation to series scraped from this deployment.
-  Autoscaler evaluations always apply this isolation automatically.
+- `deployment` (required): function whose isolated metrics scope is evaluated.
+- `source` (optional): configured external source name. When present, the endpoint
+  applies the same source scope, freshness and metric-presence checks as the autoscaler.
+  When omitted, it evaluates the function's local pod metrics.
 
 #### Successful response (200)
 
@@ -894,7 +941,9 @@ This is the final scalar value returned by the PromQL mini-evaluator.
 
 ```bash
 curl -X POST "http://localhost:5000/debug/promql/eval"   -H "Content-Type: application/json"   -d '{
-    "query": "max_over_time(slimfaas_function_queue_ready_items{function=\"fibonacci\"}[30s])"
+    "query": "max_over_time(slimfaas_function_queue_ready_items{function=\"fibonacci\"}[30s])",
+    "deployment": "fibonacci",
+    "source": "slimfaas"
   }'
 ```
 
@@ -910,7 +959,8 @@ Possible response:
 
 ```bash
 curl -X POST "http://localhost:5000/debug/promql/eval"   -H "Content-Type: application/json"   -d '{
-    "query": "sum(rate(http_server_requests_seconds_count{namespace=\"default\",job=\"fibonacci\"}[1m]))"
+    "query": "sum(rate(http_server_requests_seconds_count{namespace=\"default\",job=\"fibonacci\"}[1m]))",
+    "deployment": "fibonacci"
   }'
 ```
 
@@ -1092,10 +1142,10 @@ for each function:
      - Else:
          proposedReplicas = currentReplicas
 
-  4. Prometheus-based N→M system:
+  4. OpenMetrics / PromQL system:
 
      - If there is a SlimFaas/Scale annotation with at least one trigger
-       AND currentReplicas > 0:
+       AND either currentReplicas > 0 or at least one trigger has an external Source:
 
          desiredFromMetrics = AutoScaler(proposedReplicas, metrics...)
 
@@ -1116,8 +1166,9 @@ for each function:
 
 Key points:
 
-- The **HTTP/schedule system always runs first**, and is the only one that can propose a transition from `0` to `> 0`.
-- The **Prometheus AutoScaler only runs if `currentReplicas > 0`**.
+- The **HTTP/schedule system always runs first**. External metrics can independently
+  propose a transition from `0` to `> 0`.
+- At zero, only external triggers are evaluated; pod-local triggers are ignored.
 - When `ReplicasMin = 0` and a `SlimFaas/Scale` configuration has at least one trigger, **scale-to-zero requires both subsystems to agree**:
     - HTTP/schedule must declare the function idle enough to go down to 0,
     - metrics must also say that `desiredReplicas <= 0`.
@@ -1169,7 +1220,7 @@ Interpretation:
 - Scale-up/down formula:
 
   ```text
-  desiredReplicas = ceil(currentReplicas * (currentRps / 20))
+  desiredReplicas = ceil(currentRps / 20)
   ```
 
 - After 5 minutes with no activity (HTTP or schedule), the HTTP/schedule system **proposes** scaling the function down to 0.
@@ -1198,6 +1249,12 @@ metadata:
     SlimFaas/Scale: >
       {
         "ReplicaMax": 50,
+        "Sources": [
+          {
+            "Name": "slimfaas",
+            "Url": "http://slimfaas.default.svc.cluster.local:5000/metrics"
+          }
+        ],
         "Triggers": [
           {
             "MetricType": "AverageValue",
@@ -1209,7 +1266,8 @@ metadata:
             "MetricType": "Value",
             "MetricName": "queue_length",
             "Query": "sum(slimfaas_function_queue_ready_items{function=\"${app}\"})",
-            "Threshold": 200
+            "Threshold": 200,
+            "Source": "slimfaas"
           }
         ],
         "Behavior": {
@@ -1295,10 +1353,11 @@ spec:
     - Add a `ScaleDown` stabilization window.
     - Use smaller percent values (e.g., 50%) to avoid aggressive shrink.
 
-5. **Never rely on Prometheus to wake from 0**
-    - Prometheus metrics require pods to be running and scraped.
-    - In SlimFaas, **only HTTP/schedule controls 0 → N**.
-    - When `SlimFaas/Scale` has at least one trigger and `ReplicasMin = 0`, metrics also act as a **safety net** for 0 → N → 0 by vetoing scale-to-zero if they still indicate that capacity is needed.
+5. **Use an independent source for metric-based wake-up**
+    - Pod-local metrics disappear when the function reaches zero and cannot wake it.
+    - Configure `Sources` and `Triggers[].Source` for an exporter that remains available,
+      such as a queue, broker, or SlimFaas control-plane endpoint.
+    - Keep source names low-cardinality; URLs and PromQL text are never telemetry labels.
 
 6. **Document each trigger**
     - Use `MetricName` for clear semantic names.
@@ -1342,15 +1401,12 @@ To understand and debug autoscaling behavior:
 
 ## FAQ
 
-### Q1. Why does the AutoScaler never wake a function from 0?
+### Q1. How can the AutoScaler wake a function from 0?
 
-By design:
-
-- SlimFaas **only allows the HTTP/schedule system to wake functions from 0**.
-- The Prometheus AutoScaler only adjusts **existing** capacity.
-- When `SlimFaas/Scale` has at least one trigger, metrics can **prevent** a function from going back to 0 (by vetoing scale-to-zero), but they can **never** create the first replica from 0.
-
-This avoids relying on metrics that cannot exist while no pod is running.
+Attach the trigger to a named external OpenMetrics source that remains available while
+the function is stopped. SlimFaas evaluates external triggers at zero and applies the
+normal formula, limits, policies, and stabilization. A trigger without `Source` remains
+pod-local and is ignored at zero, preventing stale local samples from waking the function.
 
 ---
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -42,6 +42,13 @@ kubectl apply -f deployment-kafka.yml
 docker run -d -p 8000:8000 --rm axaguildev/fibonacci-webapp:latest
 ```
 
+The demo manifests expose the SlimFaas and SlimFaasKafka queue metrics through
+Services. Functions can reference those always-on endpoints with named
+`SlimFaas/Scale.Sources`, allowing queue pressure to wake a function from zero.
+See [Autoscaling](autoscaling.md#configuring-metrics-based-scaling) for the schema
+and [Native Local Mode](native-local-mode.md#validate-external-openmetrics-autoscaling)
+for the reproducible `0 → 2 → 4 → 0` integration test.
+
 ### Test Synchronous Calls
 If you used slimfaas-nodeport.yml, port 30021 might be exposed. You can call your functions via SlimFaas:
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -43,7 +43,7 @@ SlimFaas puts autoscaling at the center of the design:
 - **Two-phase scaling model**
     - **`0 → N`**: driven by HTTP history, schedules, dependencies **and Kafka lag (via SlimFaas Kafka)** to bring functions online only when needed.
     - **`N → M`**: driven by Prometheus metrics and a built-in PromQL mini-evaluator.
-    - The metrics-based autoscaler only runs once at least one pod exists — no “metrics from the void”.
+    - Named external OpenMetrics sources can wake a function from zero and continue driving `N → M` scaling.
 
 - **PromQL-driven autoscaler (no external HPA required)**
     - Write PromQL-style triggers like:
@@ -54,7 +54,7 @@ SlimFaas puts autoscaling at the center of the design:
     - Scale-up/scale-down policies and stabilization windows inspired by HPA/KEDA.
 
 - **Integrated metrics scraper (no Prometheus mandatory in the hot path)**
-    - SlimFaas scrapes **only** the HTTP metrics endpoints of pods with Prometheus annotations.
+    - SlimFaas scrapes pod endpoints with Prometheus annotations and named external HTTP/HTTPS OpenMetrics endpoints.
     - It stores **only the metrics you actually request** in your triggers or debug queries.
     - A single SlimFaas node is responsible for scraping and writing to the shared store; all nodes read from it.
 

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -200,8 +200,13 @@ Metrics include:
 The metrics exported by `KafkaMonitoringWorker` can be used directly by the **SlimFaas PromQL-based autoscaler** (the HPA-like `SlimFaas/Scale` mechanism). Below are ready-to-use examples of PromQL queries that are compatible with the SlimFaas PromQL mini-evaluator and that you can plug into `SlimFaas/Scale.Triggers[].Query`.
 
 > All examples assume that:
-> - `slimfaaskafka_*` metrics are scraped by the SlimFaas metrics scraper,
+> - `slimfaas-kafka` has a Service exposing port `8080`,
+> - that Service is configured as the named source `slimfaas-kafka`,
 > - the label `function` corresponds to the SlimFaas function name (usually `${app}` in your annotations).
+
+Because this exporter is independent from the consumer function, these triggers can
+wake the consumer from zero. The source remains subject to the normal scrape timeout,
+size, freshness, and fail-safe scale-down checks.
 
 ### 1. Scale out based on Kafka pending messages (queue length)
 
@@ -212,12 +217,17 @@ annotations:
   SlimFaas/Scale: >
     {
       "ReplicaMax": 50,
+      "Sources": [{
+        "Name": "slimfaas-kafka",
+        "Url": "http://slimfaas-kafka.slimfaas-demo.svc.cluster.local:8080/metrics"
+      }],
       "Triggers": [
         {
-          "MetricType": "Value",
+          "MetricType": "AverageValue",
           "MetricName": "kafka_pending_messages_max_30s",
           "Query": "max_over_time(slimfaaskafka_pending_messages{function=\"${app}\"}[30s])",
-          "Threshold": 200
+          "Threshold": 200,
+          "Source": "slimfaas-kafka"
         }
       ]
     }
@@ -227,10 +237,10 @@ annotations:
 
 - PromQL: `max_over_time(slimfaaskafka_pending_messages{function="${app}"}[30s])`
     - Looks at the **maximum** pending messages for this function over the last 30 seconds.
-- `MetricType = "Value"`:
-    - The threshold is interpreted as the **total** value we’re willing to accept.
+- `MetricType = "AverageValue"`:
+    - The threshold is interpreted as pending messages per desired replica.
 - `Threshold = 200`:
-    - If the max pending messages in the last 30s is 400, the SlimFaas autoscaler will aim for roughly `2 × currentReplicas` (subject to policies and caps).
+    - If the max pending messages in the last 30s is 400, the SlimFaas autoscaler will aim for `2` replicas (subject to policies and caps), including from zero.
 - This is ideal when you want to **react to bursty Kafka queues**.
 
 ### 2. Scale based on average pending messages (smooth queue pressure)
@@ -243,12 +253,17 @@ annotations:
   SlimFaas/Scale: >
     {
       "ReplicaMax": 50,
+      "Sources": [{
+        "Name": "slimfaas-kafka",
+        "Url": "http://slimfaas-kafka.slimfaas-demo.svc.cluster.local:8080/metrics"
+      }],
       "Triggers": [
         {
-          "MetricType": "Value",
+          "MetricType": "AverageValue",
           "MetricName": "kafka_pending_messages_instant",
           "Query": "sum(slimfaaskafka_pending_messages{function=\"${app}\"})",
-          "Threshold": 100
+          "Threshold": 100,
+          "Source": "slimfaas-kafka"
         }
       ]
     }
@@ -284,12 +299,17 @@ annotations:
   SlimFaas/Scale: >
     {
       "ReplicaMax": 20,
+      "Sources": [{
+        "Name": "slimfaas-kafka",
+        "Url": "http://slimfaas-kafka.slimfaas-demo.svc.cluster.local:8080/metrics"
+      }],
       "Triggers": [
         {
           "MetricType": "Value",
           "MetricName": "kafka_wakeups_per_minute",
           "Query": "sum(rate(slimfaaskafka_wakeups_total{function=\"${app}\"}[1m]))",
-          "Threshold": 5
+          "Threshold": 5,
+          "Source": "slimfaas-kafka"
         }
       ]
     }
@@ -314,18 +334,24 @@ annotations:
   SlimFaas/Scale: >
     {
       "ReplicaMax": 50,
+      "Sources": [{
+        "Name": "slimfaas-kafka",
+        "Url": "http://slimfaas-kafka.slimfaas-demo.svc.cluster.local:8080/metrics"
+      }],
       "Triggers": [
         {
-          "MetricType": "Value",
+          "MetricType": "AverageValue",
           "MetricName": "kafka_pending_messages_max_30s",
           "Query": "max_over_time(slimfaaskafka_pending_messages{function=\"${app}\"}[30s])",
-          "Threshold": 200
+          "Threshold": 200,
+          "Source": "slimfaas-kafka"
         },
         {
           "MetricType": "Value",
           "MetricName": "kafka_wakeups_per_minute",
           "Query": "sum(rate(slimfaaskafka_wakeups_total{function=\"${app}\"}[1m]))",
-          "Threshold": 2
+          "Threshold": 2,
+          "Source": "slimfaas-kafka"
         }
       ],
       "Behavior": {

--- a/docs/native-local-mode.md
+++ b/docs/native-local-mode.md
@@ -84,6 +84,40 @@ curl http://127.0.0.1:30020/status-functions
 curl http://127.0.0.1:30020/function/fibonacci1/hello/local
 ```
 
+### Validate external OpenMetrics autoscaling
+
+The repository includes a reproducible local integration scenario with an auxiliary
+exporter that remains active while its function is at zero. Run:
+
+```bash
+.bin/slimfaas-local-external-metrics-test.sh
+```
+
+The script builds SlimFaas and `SlimFaasBenchmark`, validates
+`benchmarks/slimfaas.local.external-metrics.yaml`, starts a one-node local cluster,
+and changes the exported gauge to verify `0 → 2 → 4 → 0` through
+`/status-function/benchmark-external-scale`. It terminates the managed processes on
+exit and preserves logs under `artifacts/slimfaas-local-external-metrics/` on failure.
+
+The manifest demonstrates the local configuration shape:
+
+```json
+{
+  "Sources": [
+    { "Name": "benchmark-exporter", "Url": "http://127.0.0.1:31180/metrics" }
+  ],
+  "Triggers": [
+    {
+      "MetricType": "AverageValue",
+      "MetricName": "external_pressure",
+      "Query": "slimfaas_benchmark_external_pressure",
+      "Threshold": 1,
+      "Source": "benchmark-exporter"
+    }
+  ]
+}
+```
+
 ## Manifests and overlays
 
 Select another manifest with `-f` or `--file`. Repeat the option to apply

--- a/slimfaas.local.yaml
+++ b/slimfaas.local.yaml
@@ -40,12 +40,19 @@ functions:
       SlimFaas/Scale: >
         {
           "ReplicaMax": 10,
+          "Sources": [
+            {
+              "Name": "slimfaas",
+              "Url": "http://127.0.0.1:30021/metrics"
+            }
+          ],
           "Triggers": [
             {
-              "MetricType": "Value",
+              "MetricType": "AverageValue",
               "MetricName": "max_over_time_queue_fibonacci1",
               "Query": "max_over_time(slimfaas_function_queue_ready_items{function=\"fibonacci1\"}[30s])",
-              "Threshold": 10
+              "Threshold": 10,
+              "Source": "slimfaas"
             }
           ],
           "Behavior": {

--- a/src/SlimFaas/ClientApp/src/components/FunctionTable.tsx
+++ b/src/SlimFaas/ClientApp/src/components/FunctionTable.tsx
@@ -207,7 +207,9 @@ const FunctionTable: React.FC<Props> = ({ functions, onWakeUp, coolingDown = new
                       <span className="function-table__scale-val">
                         {fn.Scale.Triggers.map((t, i) => (
                           <span key={i} className="function-table__trigger-item">
-                            <code className="function-table__trigger-code">{t.MetricName || t.Query}</code>
+                            <code className="function-table__trigger-code">
+                              {t.MetricName || t.Query}{t.Source ? ` @${t.Source}` : ''}
+                            </code>
                             <span className="function-table__replicas-info">{t.MetricType}&nbsp;≥&nbsp;{t.Threshold}</span>
                           </span>
                         ))}
@@ -286,4 +288,3 @@ const FunctionTable: React.FC<Props> = ({ functions, onWakeUp, coolingDown = new
 };
 
 export default FunctionTable;
-

--- a/src/SlimFaas/ClientApp/src/stories/FunctionTable.stories.tsx
+++ b/src/SlimFaas/ClientApp/src/stories/FunctionTable.stories.tsx
@@ -67,8 +67,9 @@ const FUNCTIONS_ALL_DOWN: FunctionStatusDetailed[] = [
     Schedule: { TimeZoneID: 'GB', Default: { WakeUp: ['0 8 * * 1-5'], ScaleDownTimeout: [] } },
     Scale: {
       ReplicaMax: 5,
+      Sources: [{ Name: 'queue', Url: 'http://queue-exporter:9090/metrics' }],
       Triggers: [
-        { MetricType: 'AverageValue', MetricName: 'http_requests_per_second', Query: '', Threshold: 100 },
+        { MetricType: 'AverageValue', MetricName: 'queue_depth', Query: 'queue_depth', Threshold: 100, Source: 'queue' },
       ],
       Behavior: {
         ScaleUp: { StabilizationWindowSeconds: 0, Policies: [{ Type: 'Percent', Value: 100, PeriodSeconds: 15 }, { Type: 'Pods', Value: 4, PeriodSeconds: 15 }] },
@@ -214,4 +215,3 @@ export const Empty: Story = {
   name: 'No functions',
   args: { functions: [] },
 };
-

--- a/src/SlimFaas/ClientApp/src/tooltips.ts
+++ b/src/SlimFaas/ClientApp/src/tooltips.ts
@@ -49,10 +49,10 @@ export const FN = {
     'Async retry configuration: HTTP timeout per attempt, retry delays in seconds between attempts, and HTTP status codes that trigger a retry (SlimFaas/DefaultAsync).',
 
   maxReplicas:
-    'Upper bound for the Prometheus-based N→M autoscaler (SlimFaas/Scale → ReplicaMax).',
+    'Upper bound for PromQL-based autoscaling, including external-source wake-up from zero (SlimFaas/Scale → ReplicaMax).',
 
   triggers:
-    'Prometheus metrics triggers for N→M autoscaling (SlimFaas/Scale → Triggers). Each trigger defines a metric, a threshold, and a metric type (AverageValue or Value).',
+    'OpenMetrics triggers for autoscaling. Pod metrics adjust N→M; named external sources can also wake a function from zero. Each trigger defines a metric, threshold, metric type, and optional source.',
 
   behavior:
     'Scale-up and scale-down stabilization and rate-limiting policies (SlimFaas/Scale → Behavior).',
@@ -103,4 +103,3 @@ export const JOB = {
   memResources:
     'Kubernetes Memory request / limit for this job.',
 } as const;
-

--- a/src/SlimFaas/ClientApp/src/types.ts
+++ b/src/SlimFaas/ClientApp/src/types.ts
@@ -42,6 +42,12 @@ export interface ScaleTrigger {
   MetricName: string;
   Query: string;
   Threshold: number;
+  Source?: string | null;
+}
+
+export interface ScaleSource {
+  Name: string;
+  Url: string;
 }
 
 export interface ScalePolicy {
@@ -62,7 +68,9 @@ export interface ScaleBehavior {
 
 export interface ScaleConfig {
   ReplicaMax: number | null;
+  ScrapeIntervalMilliseconds?: number | null;
   Triggers: ScaleTrigger[];
+  Sources: ScaleSource[];
   Behavior: ScaleBehavior;
 }
 

--- a/src/SlimFaas/Kubernetes/AutoScaler.cs
+++ b/src/SlimFaas/Kubernetes/AutoScaler.cs
@@ -8,6 +8,7 @@ public sealed class AutoScaler
     private readonly IAutoScalerStore _store;
     private readonly InMemoryAutoScalerStore _recommendationStore = new();
     private readonly ILogger<AutoScaler>? _logger;
+    private readonly IExternalMetricsSourceHealthRegistry _externalHealthRegistry;
     private readonly ConcurrentDictionary<string, CachedQuery> _queryCache =
         new(StringComparer.Ordinal);
 
@@ -17,11 +18,13 @@ public sealed class AutoScaler
     public AutoScaler(
         PromQlMiniEvaluator evaluator,
         IAutoScalerStore store,
-        ILogger<AutoScaler>? logger = null)
+        ILogger<AutoScaler>? logger = null,
+        IExternalMetricsSourceHealthRegistry? externalHealthRegistry = null)
     {
         _evaluator = evaluator ?? throw new ArgumentNullException(nameof(evaluator));
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _logger = logger;
+        _externalHealthRegistry = externalHealthRegistry ?? new ExternalMetricsSourceHealthRegistry();
     }
 
     public int ComputeDesiredReplicas(DeploymentInformation deployment, long nowUnixSeconds)
@@ -150,17 +153,25 @@ public sealed class AutoScaler
 
         foreach (var trigger in config.Triggers)
         {
+            string sourceLabel = MetricsSourceScope.Label(trigger.Source);
             if (string.IsNullOrWhiteSpace(trigger.Query))
             {
                 hasInvalidTrigger = true;
-                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                 continue;
             }
 
             if (trigger.Threshold <= 0)
             {
                 hasInvalidTrigger = true;
-                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
+                continue;
+            }
+
+            if (trigger.Source is null && currentReplicas == 0)
+            {
+                hasInvalidTrigger = true;
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                 continue;
             }
 
@@ -176,11 +187,47 @@ public sealed class AutoScaler
                         trigger.Query,
                         trigger.MetricName,
                         cachedQuery.Error);
-                    AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                    AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                     continue;
                 }
 
-                metricValue = _evaluator.Evaluate(cachedQuery.Query, nowUnixSeconds, key);
+                string scope = key;
+                TimeSpan? externalLookback = null;
+                if (trigger.Source is not null)
+                {
+                    scope = MetricsSourceScope.ForExternal(key, trigger.Source);
+                    if (!_externalHealthRegistry.IsHealthy(
+                            scope,
+                            nowUnixSeconds,
+                            cachedQuery.Query.ReferencedMetricNames,
+                            out string healthReason))
+                    {
+                        hasInvalidTrigger = true;
+                        _logger?.LogWarning(
+                            "External metrics source {Source} is invalid for function {Function}: {Reason}",
+                            trigger.Source,
+                            key,
+                            healthReason);
+                        AutoScalerTelemetry.RecordTrigger(
+                            key,
+                            trigger.MetricName,
+                            sourceLabel,
+                            0,
+                            isValid: false);
+                        continue;
+                    }
+
+                    if (_externalHealthRegistry.TryGet(scope, out ExternalMetricsSourceHealth? health) &&
+                        health is not null)
+                    {
+                        externalLookback = TimeSpan.FromMilliseconds(
+                            health.ScrapeIntervalMilliseconds * 3L);
+                    }
+                }
+
+                metricValue = externalLookback.HasValue
+                    ? _evaluator.Evaluate(cachedQuery.Query, nowUnixSeconds, scope, externalLookback.Value)
+                    : _evaluator.Evaluate(cachedQuery.Query, nowUnixSeconds, scope);
             }
             catch (FormatException ex)
             {
@@ -189,7 +236,7 @@ public sealed class AutoScaler
                     trigger.Query,
                     trigger.MetricName);
                 hasInvalidTrigger = true;
-                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                 continue;
             }
             catch (InvalidOperationException ex)
@@ -198,7 +245,7 @@ public sealed class AutoScaler
                     "InvalidOperationException while evaluating PromQL query '{Query}'",
                     trigger.Query);
                 hasInvalidTrigger = true;
-                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                 continue;
             }
             catch (ArgumentException ex)
@@ -207,25 +254,25 @@ public sealed class AutoScaler
                     "ArgumentException while evaluating PromQL query '{Query}'",
                     trigger.Query);
                 hasInvalidTrigger = true;
-                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                 continue;
             }
 
             if (double.IsNaN(metricValue) || double.IsInfinity(metricValue))
             {
                 hasInvalidTrigger = true;
-                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                 continue;
             }
 
             if (metricValue < 0)
             {
                 hasInvalidTrigger = true;
-                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, 0, isValid: false);
+                AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, 0, isValid: false);
                 continue;
             }
 
-            AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, metricValue, isValid: true);
+            AutoScalerTelemetry.RecordTrigger(key, trigger.MetricName, sourceLabel, metricValue, isValid: true);
 
             var effectiveCurrent = currentReplicas == 0 ? 1 : currentReplicas;
             var ratio = metricValue / trigger.Threshold;

--- a/src/SlimFaas/Kubernetes/AutoScalerTelemetry.cs
+++ b/src/SlimFaas/Kubernetes/AutoScalerTelemetry.cs
@@ -9,13 +9,15 @@ internal static class AutoScalerTelemetry
         "slimfaas_autoscaler_trigger_value",
         "Latest value evaluated for an autoscaling trigger.",
         "function",
-        "metric");
+        "metric",
+        "source");
 
     private static readonly Gauge TriggerValid = Metrics.CreateGauge(
         "slimfaas_autoscaler_trigger_valid",
         "Whether the latest autoscaling trigger evaluation produced usable data.",
         "function",
-        "metric");
+        "metric",
+        "source");
 
     private static readonly Gauge CurrentReplicas = Metrics.CreateGauge(
         "slimfaas_autoscaler_current_replicas",
@@ -45,12 +47,13 @@ internal static class AutoScalerTelemetry
     public static void RecordTrigger(
         string key,
         string metricName,
+        string source,
         double value,
         bool isValid)
     {
         var metric = string.IsNullOrWhiteSpace(metricName) ? "unnamed" : metricName;
-        TriggerValue.WithLabels(key, metric).Set(isValid ? value : 0);
-        TriggerValid.WithLabels(key, metric).Set(isValid ? 1 : 0);
+        TriggerValue.WithLabels(key, metric, source).Set(isValid ? value : 0);
+        TriggerValid.WithLabels(key, metric, source).Set(isValid ? 1 : 0);
     }
 
     public static void RecordDecision(

--- a/src/SlimFaas/Kubernetes/ExternalMetricsSourceHealthRegistry.cs
+++ b/src/SlimFaas/Kubernetes/ExternalMetricsSourceHealthRegistry.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+
+namespace SlimFaas.Kubernetes;
+
+public sealed record ExternalMetricsSourceHealth(
+    bool LastAttemptSucceeded,
+    long LastAttemptUnixSeconds,
+    long? LastSuccessUnixSeconds,
+    int ScrapeIntervalMilliseconds,
+    IReadOnlySet<string> ObservedMetricNames);
+
+public interface IExternalMetricsSourceHealthRegistry
+{
+    void RecordSuccess(
+        string scope,
+        long timestampUnixSeconds,
+        int scrapeIntervalMilliseconds,
+        IEnumerable<string> observedMetricKeys);
+
+    void RecordFailure(string scope, long timestampUnixSeconds, int scrapeIntervalMilliseconds);
+
+    bool IsHealthy(
+        string scope,
+        long nowUnixSeconds,
+        IReadOnlySet<string> requiredMetricNames,
+        out string reason);
+
+    bool TryGet(string scope, out ExternalMetricsSourceHealth? health);
+
+    void RetainScopes(IReadOnlySet<string> scopes);
+}
+
+public sealed class ExternalMetricsSourceHealthRegistry : IExternalMetricsSourceHealthRegistry
+{
+    private readonly ConcurrentDictionary<string, ExternalMetricsSourceHealth> _states =
+        new(StringComparer.Ordinal);
+
+    public void RecordSuccess(
+        string scope,
+        long timestampUnixSeconds,
+        int scrapeIntervalMilliseconds,
+        IEnumerable<string> observedMetricKeys)
+    {
+        var names = observedMetricKeys
+            .Select(GetMetricName)
+            .Where(static name => name.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+        _states[scope] = new ExternalMetricsSourceHealth(
+            true,
+            timestampUnixSeconds,
+            timestampUnixSeconds,
+            scrapeIntervalMilliseconds,
+            names);
+    }
+
+    public void RecordFailure(string scope, long timestampUnixSeconds, int scrapeIntervalMilliseconds)
+    {
+        _states.AddOrUpdate(
+            scope,
+            _ => new ExternalMetricsSourceHealth(
+                false,
+                timestampUnixSeconds,
+                null,
+                scrapeIntervalMilliseconds,
+                new HashSet<string>(StringComparer.Ordinal)),
+            (_, previous) => previous with
+            {
+                LastAttemptSucceeded = false,
+                LastAttemptUnixSeconds = timestampUnixSeconds,
+                ScrapeIntervalMilliseconds = scrapeIntervalMilliseconds
+            });
+    }
+
+    public bool IsHealthy(
+        string scope,
+        long nowUnixSeconds,
+        IReadOnlySet<string> requiredMetricNames,
+        out string reason)
+    {
+        if (!_states.TryGetValue(scope, out ExternalMetricsSourceHealth? state))
+        {
+            reason = "source_not_scraped";
+            return false;
+        }
+
+        if (!state.LastAttemptSucceeded || state.LastSuccessUnixSeconds is null)
+        {
+            reason = "last_scrape_failed";
+            return false;
+        }
+
+        long freshnessSeconds = Math.Max(
+            1,
+            (state.ScrapeIntervalMilliseconds * 3L + 999L) / 1_000L);
+        long ageSeconds = nowUnixSeconds - state.LastSuccessUnixSeconds.Value;
+        if (ageSeconds < 0 || ageSeconds > freshnessSeconds)
+        {
+            reason = "source_stale";
+            return false;
+        }
+
+        if (requiredMetricNames.Any(name => !state.ObservedMetricNames.Contains(name)))
+        {
+            reason = "metric_missing";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    public bool TryGet(string scope, out ExternalMetricsSourceHealth? health) =>
+        _states.TryGetValue(scope, out health);
+
+    public void RetainScopes(IReadOnlySet<string> scopes)
+    {
+        foreach (string scope in _states.Keys)
+        {
+            if (!scopes.Contains(scope))
+                _states.TryRemove(scope, out _);
+        }
+    }
+
+    private static string GetMetricName(string metricKey)
+    {
+        int labelsStart = metricKey.IndexOf('{', StringComparison.Ordinal);
+        return labelsStart < 0 ? metricKey : metricKey[..labelsStart];
+    }
+}

--- a/src/SlimFaas/Kubernetes/FunctionMetadataParser.cs
+++ b/src/SlimFaas/Kubernetes/FunctionMetadataParser.cs
@@ -132,6 +132,50 @@ public static class FunctionMetadataParser
                 $"{ScaleConfig.MaximumScrapeIntervalMilliseconds}.");
         }
 
+        var sources = new List<ScaleSource>();
+        var sourceNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (ScaleSource? source in scale.Sources ?? [])
+        {
+            if (source is null)
+                throw new FormatException($"{FunctionAnnotationNames.Scale}.Sources cannot contain null values.");
+
+            string name = source.Name?.Trim() ?? string.Empty;
+            string url = source.Url?.Trim() ?? string.Empty;
+            if (name.Length == 0)
+                throw new FormatException($"{FunctionAnnotationNames.Scale}.Sources[].Name is required.");
+            if (!sourceNames.Add(name))
+                throw new FormatException(
+                    $"{FunctionAnnotationNames.Scale}.Sources contains duplicate source name '{name}'.");
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? uri) ||
+                (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
+                string.IsNullOrWhiteSpace(uri.Host) ||
+                !string.IsNullOrEmpty(uri.UserInfo) ||
+                !string.IsNullOrEmpty(uri.Fragment))
+            {
+                throw new FormatException(
+                    $"{FunctionAnnotationNames.Scale}.Sources['{name}'].Url must be an absolute HTTP or HTTPS URL " +
+                    "without credentials or a fragment.");
+            }
+
+            sources.Add(source with { Name = name, Url = uri.AbsoluteUri });
+        }
+
+        var triggers = new List<ScaleTrigger>();
+        foreach (ScaleTrigger? trigger in scale.Triggers ?? [])
+        {
+            if (trigger is null)
+                throw new FormatException($"{FunctionAnnotationNames.Scale}.Triggers cannot contain null values.");
+
+            string? source = string.IsNullOrWhiteSpace(trigger.Source) ? null : trigger.Source.Trim();
+            if (source is not null && !sourceNames.Contains(source))
+            {
+                throw new FormatException(
+                    $"{FunctionAnnotationNames.Scale}.Triggers references unknown source '{source}'.");
+            }
+
+            triggers.Add(trigger with { Source = source });
+        }
+
         ScaleBehavior behavior = scale.Behavior ?? new ScaleBehavior();
         ScaleDirectionBehavior scaleUp = behavior.ScaleUp ?? ScaleDirectionBehavior.DefaultScaleUp();
         ScaleDirectionBehavior scaleDown = behavior.ScaleDown ?? ScaleDirectionBehavior.DefaultScaleDown();
@@ -144,7 +188,8 @@ public static class FunctionMetadataParser
 
         return scale with
         {
-            Triggers = scale.Triggers ?? [],
+            Sources = sources,
+            Triggers = triggers,
             Behavior = behavior with
             {
                 ScaleUp = scaleUp with { Policies = upPolicies },

--- a/src/SlimFaas/Kubernetes/MetricsSourceScope.cs
+++ b/src/SlimFaas/Kubernetes/MetricsSourceScope.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace SlimFaas.Kubernetes;
+
+public static class MetricsSourceScope
+{
+    public const string LocalSourceName = "pods";
+
+    public static string ForExternal(string function, string source)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(function);
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"external:{function.Length}:{function}:{source}");
+    }
+
+    public static string Label(string? source) =>
+        string.IsNullOrWhiteSpace(source) ? LocalSourceName : source;
+}

--- a/src/SlimFaas/Kubernetes/PromQlMiniEvaluator.cs
+++ b/src/SlimFaas/Kubernetes/PromQlMiniEvaluator.cs
@@ -55,8 +55,27 @@ public sealed class PromQlMiniEvaluator
         return compiled.Root.Eval(ctx).AsScalar();
     }
 
-    private EvalContext? BuildContext(long? nowUnixSeconds, string? deployment)
+    public double Evaluate(
+        CompiledPromQlQuery compiled,
+        long? nowUnixSeconds,
+        string? deployment,
+        TimeSpan instantSelectorLookback)
     {
+        ArgumentNullException.ThrowIfNull(compiled);
+        var ctx = BuildContext(
+            nowUnixSeconds,
+            deployment,
+            ValidateInstantSelectorLookback(instantSelectorLookback));
+        if (ctx is null) return double.NaN;
+        return compiled.Root.Eval(ctx).AsScalar();
+    }
+
+    private EvalContext? BuildContext(
+        long? nowUnixSeconds,
+        string? deployment,
+        TimeSpan? instantSelectorLookback = null)
+    {
+        TimeSpan lookback = instantSelectorLookback ?? _instantSelectorLookback;
         if (_metricsStore is not null)
         {
             if (_metricsStore.LatestTimestamp is not { } latestTimestamp)
@@ -65,7 +84,7 @@ public sealed class PromQlMiniEvaluator
             return new EvalContext(
                 _metricsStore,
                 nowUnixSeconds ?? latestTimestamp,
-                _instantSelectorLookback,
+                lookback,
                 deployment);
         }
 
@@ -76,7 +95,7 @@ public sealed class PromQlMiniEvaluator
         return new EvalContext(
             snapshot,
             nowUnixSeconds ?? snapshot.Keys.Max(),
-            _instantSelectorLookback,
+            lookback,
             deployment);
     }
 

--- a/src/SlimFaas/Kubernetes/Scale.cs
+++ b/src/SlimFaas/Kubernetes/Scale.cs
@@ -20,7 +20,13 @@ public record ScaleTrigger(
     ScaleMetricType MetricType = ScaleMetricType.AverageValue,
     string MetricName = "",
     string Query = "",
-    double Threshold = 0
+    double Threshold = 0,
+    string? Source = null
+);
+
+public record ScaleSource(
+    string Name = "",
+    string Url = ""
 );
 
 public record ScalePolicy(
@@ -74,6 +80,9 @@ public record ScaleConfig
 
     // Par défaut, pas de triggers si non fournis
     public IList<ScaleTrigger> Triggers { get; init; } = new List<ScaleTrigger>();
+
+    // Named external OpenMetrics endpoints available to triggers.
+    public IList<ScaleSource> Sources { get; init; } = new List<ScaleSource>();
 
     // Par défaut, comportement = defaults ci-dessus
     public ScaleBehavior Behavior { get; init; } = new();

--- a/src/SlimFaas/Program.cs
+++ b/src/SlimFaas/Program.cs
@@ -204,6 +204,9 @@ serviceCollectionStarter.AddSingleton<PromQlMiniEvaluator>(sp =>
 
 // Store d’historique de décisions de scaling
 serviceCollectionStarter.AddSingleton<IAutoScalerStore, InMemoryAutoScalerStore>();
+serviceCollectionStarter.AddSingleton<
+    IExternalMetricsSourceHealthRegistry,
+    ExternalMetricsSourceHealthRegistry>();
 
 // AutoScaler (utilisé par ReplicasService)
 serviceCollectionStarter.AddSingleton<AutoScaler>();
@@ -239,6 +242,9 @@ serviceCollectionSlimFaas.AddSingleton<PromQlMiniEvaluator>(sp =>
 serviceCollectionSlimFaas.AddSingleton<IAutoScalerStore>(sp =>
     serviceProviderStarter.GetRequiredService<IAutoScalerStore>());
 
+serviceCollectionSlimFaas.AddSingleton<IExternalMetricsSourceHealthRegistry>(sp =>
+    serviceProviderStarter.GetRequiredService<IExternalMetricsSourceHealthRegistry>());
+
 serviceCollectionSlimFaas.AddSingleton<AutoScaler>(sp =>
     serviceProviderStarter.GetRequiredService<AutoScaler>());
 serviceCollectionSlimFaas.AddHostedService<SlimQueuesWorker>();
@@ -254,6 +260,9 @@ serviceCollectionSlimFaas.AddHostedService<SlimDataDiagnosticsWorker>();
 serviceCollectionSlimFaas.AddHostedService<HealthWorker>();
 serviceCollectionSlimFaas.AddHostedService<MetricsScrapingWorker>();
 serviceCollectionSlimFaas.AddHttpClient();
+serviceCollectionSlimFaas
+    .AddHttpClient(nameof(MetricsScrapingWorker))
+    .RemoveAllLoggers();
 serviceCollectionSlimFaas.AddSingleton<ISlimFaasQueue, SlimFaasQueue>();
 serviceCollectionSlimFaas.AddSingleton<DynamicGaugeService>();
 serviceCollectionSlimFaas.AddSingleton<ISlimDataStatus, SlimDataStatus>();

--- a/src/SlimFaas/PromQL/DebugRoutes.cs
+++ b/src/SlimFaas/PromQL/DebugRoutes.cs
@@ -13,7 +13,9 @@ public static class DebugRoutes
                 PromQlRequest req,
                 PromQlMiniEvaluator eval,
                 IMetricsScrapingGuard guard,
-                IRequestedMetricsRegistry registry) =>
+                IRequestedMetricsRegistry registry,
+                IReplicasService replicasService,
+                IExternalMetricsSourceHealthRegistry externalHealthRegistry) =>
             {
                 // Active le scraping côté PromQL
                 guard.EnablePromql();
@@ -23,11 +25,59 @@ public static class DebugRoutes
 
                 if (string.IsNullOrWhiteSpace(req.Query))
                     return Results.BadRequest(new ErrorResponse { Error = "query is required" });
+                if (string.IsNullOrWhiteSpace(req.Deployment))
+                    return Results.BadRequest(new ErrorResponse { Error = "deployment is required" });
 
                 double result;
                 try
                 {
-                    result = eval.Evaluate(req.Query, req.NowUnixSeconds, req.Deployment);
+                    CompiledPromQlQuery query = PromQlQueryCompiler.Compile(req.Query);
+                    string scope = req.Deployment;
+                    TimeSpan? externalLookback = null;
+                    if (!string.IsNullOrWhiteSpace(req.Source))
+                    {
+                        DeploymentInformation? deployment = replicasService.Deployments.Functions.FirstOrDefault(
+                            function => string.Equals(
+                                function.Deployment,
+                                req.Deployment,
+                                StringComparison.Ordinal));
+                        ScaleSource? source = deployment?.Scale?.Sources.FirstOrDefault(
+                            source => string.Equals(source.Name, req.Source, StringComparison.Ordinal));
+                        if (source is null)
+                        {
+                            return Results.BadRequest(new ErrorResponse
+                            {
+                                Error = $"source '{req.Source}' is not configured for deployment '{req.Deployment}'"
+                            });
+                        }
+
+                        scope = MetricsSourceScope.ForExternal(req.Deployment, source.Name);
+                        long now = req.NowUnixSeconds ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                        if (!externalHealthRegistry.IsHealthy(
+                                scope,
+                                now,
+                                query.ReferencedMetricNames,
+                                out string reason))
+                        {
+                            return Results.BadRequest(new ErrorResponse
+                            {
+                                Error = $"source '{source.Name}' is unavailable: {reason}"
+                            });
+                        }
+
+                        if (externalHealthRegistry.TryGet(
+                                scope,
+                                out ExternalMetricsSourceHealth? health) &&
+                            health is not null)
+                        {
+                            externalLookback = TimeSpan.FromMilliseconds(
+                                health.ScrapeIntervalMilliseconds * 3L);
+                        }
+                    }
+
+                    result = externalLookback.HasValue
+                        ? eval.Evaluate(query, req.NowUnixSeconds, scope, externalLookback.Value)
+                        : eval.Evaluate(query, req.NowUnixSeconds, scope);
 
                     // IMPORTANT : filtrer NaN / ±Infinity
                     if (double.IsNaN(result) || double.IsInfinity(result))

--- a/src/SlimFaas/PromQL/PrompQLMiniApi.cs
+++ b/src/SlimFaas/PromQL/PrompQLMiniApi.cs
@@ -8,9 +8,10 @@ namespace SlimFaas;
 
 public sealed class PromQlRequest
 {
-public required string Query { get; init; }
-public long? NowUnixSeconds { get; init; }
-public string? Deployment { get; init; }
+    public required string Query { get; init; }
+    public long? NowUnixSeconds { get; init; }
+    public required string Deployment { get; init; }
+    public string? Source { get; init; }
 }
 
 public sealed class ErrorResponse

--- a/src/SlimFaas/ReplicasService.cs
+++ b/src/SlimFaas/ReplicasService.cs
@@ -121,7 +121,8 @@ public class ReplicasService(
 
             // --- Calcul commun : désir des métriques (Prometheus), si activées ---
             int? desiredFromMetrics = null;
-            if (deploymentInformation.Scale?.Triggers.Count > 0 && currentScale > 0)
+            if (deploymentInformation.Scale is { Triggers.Count: > 0 } scale &&
+                (currentScale > 0 || scale.Triggers.Any(static trigger => trigger.Source is not null)))
             {
                 desiredFromMetrics = autoScaler.ComputeDesiredReplicas(deploymentInformation, nowUnixSeconds);
             }

--- a/src/SlimFaas/Workers/MetricsScrapingTelemetry.cs
+++ b/src/SlimFaas/Workers/MetricsScrapingTelemetry.cs
@@ -9,7 +9,7 @@ internal static class MetricsScrapingTelemetry
         "Duration of one function metrics target scrape.",
         new HistogramConfiguration
         {
-            LabelNames = ["function"],
+            LabelNames = ["function", "source"],
             Buckets = Histogram.ExponentialBuckets(0.005, 2, 12)
         });
 
@@ -17,19 +17,33 @@ internal static class MetricsScrapingTelemetry
         "slimfaas_metrics_scrape_failures_total",
         "Number of function metrics scrape failures.",
         "function",
+        "source",
         "reason");
 
     private static readonly Gauge LastSuccess = Metrics.CreateGauge(
         "slimfaas_metrics_scrape_last_success_unixtime",
         "Unix timestamp of the latest successful function metrics scrape.",
-        "function");
+        "function",
+        "source");
 
-    public static void RecordDuration(string function, TimeSpan duration) =>
-        Duration.WithLabels(function).Observe(duration.TotalSeconds);
+    private static readonly Gauge SourceAvailable = Metrics.CreateGauge(
+        "slimfaas_metrics_source_available",
+        "Whether the latest external or pod metrics source scrape succeeded.",
+        "function",
+        "source");
 
-    public static void RecordFailure(string function, string reason) =>
-        Failures.WithLabels(function, reason).Inc();
+    public static void RecordDuration(string function, string source, TimeSpan duration) =>
+        Duration.WithLabels(function, source).Observe(duration.TotalSeconds);
 
-    public static void RecordSuccess(string function) =>
-        LastSuccess.WithLabels(function).Set(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+    public static void RecordFailure(string function, string source, string reason)
+    {
+        Failures.WithLabels(function, source, reason).Inc();
+        SourceAvailable.WithLabels(function, source).Set(0);
+    }
+
+    public static void RecordSuccess(string function, string source)
+    {
+        LastSuccess.WithLabels(function, source).Set(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+        SourceAvailable.WithLabels(function, source).Set(1);
+    }
 }

--- a/src/SlimFaas/Workers/MetricsScrapingWorker.cs
+++ b/src/SlimFaas/Workers/MetricsScrapingWorker.cs
@@ -19,7 +19,8 @@ public class MetricsScrapingWorker(
     IRequestedMetricsRegistry requestedMetricsRegistry,
     ILogger<MetricsScrapingWorker> logger,
     IOptions<SlimFaasOptions> slimFaasOptions,
-    int delay = 0)
+    int delay = 0,
+    IExternalMetricsSourceHealthRegistry? externalHealthRegistry = null)
     : BackgroundService
 {
     private const string MetricsStoreKey = "metrics:store";
@@ -32,12 +33,22 @@ public class MetricsScrapingWorker(
     private readonly int _scrapeIntervalMilliseconds = delay > 0
         ? delay
         : slimFaasOptions.Value.MetricsScraping.ScrapeIntervalMilliseconds;
-    private readonly Dictionary<string, long> _nextScrapeByDeployment = new(StringComparer.Ordinal);
+    private readonly IExternalMetricsSourceHealthRegistry _externalHealthRegistry =
+        externalHealthRegistry ?? new ExternalMetricsSourceHealthRegistry();
+    private readonly Dictionary<string, long> _nextScrapeByScope = new(StringComparer.Ordinal);
     private DateTimeOffset _nextPersistenceUtc = DateTimeOffset.MinValue;
     private DateTimeOffset _nextLegacyHydrationUtc = DateTimeOffset.MinValue;
     private byte[]? _lastHydratedVersion;
     private byte[]? _lastLegacyPayloadHash;
     private bool _wasMaster;
+
+    private sealed record ScrapeTarget(
+        string Scope,
+        string Function,
+        string Source,
+        string Url,
+        int IntervalMilliseconds,
+        bool IsExternal);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -92,10 +103,10 @@ public class MetricsScrapingWorker(
                     continue;
                 }
 
-                var targetsByDeployment = deployments.GetMetricsTargets();
+                var targets = GetMetricsTargets(deployments);
 
                 // Si aucune cible annotée prometheus n'existe, on ne fait rien
-                if (targetsByDeployment.Count == 0)
+                if (targets.Count == 0)
                 {
                     await DelayUntilNextScrapeCycleAsync(
                         cycleStartedTimestamp,
@@ -114,15 +125,14 @@ public class MetricsScrapingWorker(
                     continue;
                 }
 
-                var dueTargets = SelectDueTargets(deployments, targetsByDeployment);
+                var dueTargets = SelectDueTargets(targets);
                 if (dueTargets.Count > 0)
                 {
                     var ts = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                     using var concurrency = new SemaphoreSlim(_metricsScrapingOptions.MaxConcurrentTargets);
                     var scrapeTasks = dueTargets
                         .Select(target => ScrapeTargetBoundedAsync(
-                            target.Deployment,
-                            target.Url,
+                            target,
                             ts,
                             requestedMetricNames,
                             concurrency,
@@ -199,46 +209,96 @@ public class MetricsScrapingWorker(
         return minimum;
     }
 
-    private List<(string Deployment, string Url)> SelectDueTargets(
-        DeploymentsInformations deployments,
-        IDictionary<string, IList<string>> targetsByDeployment)
+    private List<ScrapeTarget> GetMetricsTargets(DeploymentsInformations deployments)
     {
         var functions = deployments.Functions.ToDictionary(
             static function => function.Deployment,
             StringComparer.Ordinal);
-        var currentDeployments = targetsByDeployment.Keys.ToHashSet(StringComparer.Ordinal);
-        foreach (var staleDeployment in _nextScrapeByDeployment.Keys
-                     .Where(key => !currentDeployments.Contains(key))
+        var result = new List<ScrapeTarget>();
+
+        foreach (var (scope, urls) in deployments.GetMetricsTargets())
+        {
+            int interval = ResolveTargetInterval(functions.GetValueOrDefault(scope));
+            result.AddRange(urls.Select(url => new ScrapeTarget(
+                scope,
+                scope,
+                MetricsSourceScope.LocalSourceName,
+                url,
+                interval,
+                IsExternal: false)));
+        }
+
+        var externalScopes = new HashSet<string>(StringComparer.Ordinal);
+        foreach (DeploymentInformation function in deployments.Functions)
+        {
+            ScaleConfig? scale = function.Scale;
+            if (scale is null || scale.Triggers.Count == 0 || scale.Sources.Count == 0)
+                continue;
+
+            var sources = scale.Sources.ToDictionary(static source => source.Name, StringComparer.Ordinal);
+            foreach (string sourceName in scale.Triggers
+                         .Select(static trigger => trigger.Source)
+                         .Where(static source => source is not null)
+                         .Select(static source => source!)
+                         .Distinct(StringComparer.Ordinal))
+            {
+                if (!sources.TryGetValue(sourceName, out ScaleSource? source))
+                    continue;
+
+                string scope = MetricsSourceScope.ForExternal(function.Deployment, sourceName);
+                externalScopes.Add(scope);
+                result.Add(new ScrapeTarget(
+                    scope,
+                    function.Deployment,
+                    sourceName,
+                    source.Url,
+                    ResolveTargetInterval(function),
+                    IsExternal: true));
+            }
+        }
+
+        _externalHealthRegistry.RetainScopes(externalScopes);
+        return result;
+    }
+
+    private int ResolveTargetInterval(DeploymentInformation? function)
+    {
+        if (!_hasDelayOverride && function?.Scale?.ScrapeIntervalMilliseconds is { } configured)
+            return configured;
+        return _scrapeIntervalMilliseconds;
+    }
+
+    private List<ScrapeTarget> SelectDueTargets(IReadOnlyCollection<ScrapeTarget> targets)
+    {
+        var currentScopes = targets.Select(static target => target.Scope).ToHashSet(StringComparer.Ordinal);
+        foreach (string staleScope in _nextScrapeByScope.Keys
+                     .Where(key => !currentScopes.Contains(key))
                      .ToArray())
         {
-            _nextScrapeByDeployment.Remove(staleDeployment);
+            _nextScrapeByScope.Remove(staleScope);
         }
 
         var now = Stopwatch.GetTimestamp();
-        var dueTargets = new List<(string Deployment, string Url)>();
-        foreach (var (deployment, urls) in targetsByDeployment)
+        var dueTargets = new List<ScrapeTarget>();
+        foreach (IGrouping<string, ScrapeTarget> group in targets.GroupBy(
+                     static target => target.Scope,
+                     StringComparer.Ordinal))
         {
-            if (_nextScrapeByDeployment.TryGetValue(deployment, out var nextScrape) && now < nextScrape)
+            if (_nextScrapeByScope.TryGetValue(group.Key, out long nextScrape) && now < nextScrape)
                 continue;
 
-            var intervalMilliseconds = _scrapeIntervalMilliseconds;
-            if (!_hasDelayOverride &&
-                functions.TryGetValue(deployment, out var function) &&
-                function.Scale?.ScrapeIntervalMilliseconds is { } configured)
-            {
-                intervalMilliseconds = configured;
-            }
-
-            _nextScrapeByDeployment[deployment] = now +
-                (long)(intervalMilliseconds / 1_000.0 * Stopwatch.Frequency);
-            dueTargets.AddRange(urls.Select(url => (deployment, url)));
+            ScrapeTarget first = group.First();
+            _nextScrapeByScope[group.Key] = now +
+                (long)(first.IntervalMilliseconds / 1_000.0 * Stopwatch.Frequency);
+            dueTargets.AddRange(group);
 
             if (logger.IsEnabled(LogLevel.Information))
             {
                 logger.LogInformation(
-                    "Scraping metrics for deployment {Deployment} with {TargetCount} targets",
-                    deployment,
-                    urls.Count);
+                    "Scraping metrics for function {Function}, source {Source}, with {TargetCount} targets",
+                    first.Function,
+                    first.Source,
+                    group.Count());
             }
         }
 
@@ -246,8 +306,7 @@ public class MetricsScrapingWorker(
     }
 
     private async Task ScrapeTargetBoundedAsync(
-        string deployment,
-        string url,
+        ScrapeTarget target,
         long timestamp,
         IReadOnlyCollection<string> requestedMetricNames,
         SemaphoreSlim concurrency,
@@ -256,7 +315,7 @@ public class MetricsScrapingWorker(
         await concurrency.WaitAsync(stoppingToken);
         try
         {
-            await ScrapeTargetAsync(deployment, url, timestamp, requestedMetricNames, stoppingToken);
+            await ScrapeTargetAsync(target, timestamp, requestedMetricNames, stoppingToken);
         }
         finally
         {
@@ -265,8 +324,7 @@ public class MetricsScrapingWorker(
     }
 
     private async Task ScrapeTargetAsync(
-        string deployment,
-        string url,
+        ScrapeTarget target,
         long timestamp,
         IReadOnlyCollection<string> requestedMetricNames,
         CancellationToken stoppingToken)
@@ -274,15 +332,15 @@ public class MetricsScrapingWorker(
         var started = Stopwatch.GetTimestamp();
         try
         {
-            var targetIdentity = GetTargetIdentityFromUrl(url);
+            var targetIdentity = target.IsExternal ? "source" : GetTargetIdentityFromUrl(target.Url);
             if (string.IsNullOrEmpty(targetIdentity))
             {
-                MetricsScrapingTelemetry.RecordFailure(deployment, "invalid_url");
+                RecordFailure(target, "invalid_url");
                 return;
             }
 
             var http = httpClientFactory.CreateClient(nameof(MetricsScrapingWorker));
-            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            using var req = new HttpRequestMessage(HttpMethod.Get, target.Url);
             using var scrapeTimeout = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
             scrapeTimeout.CancelAfter(TimeSpan.FromSeconds(_metricsScrapingOptions.RequestTimeoutSeconds));
             using var resp = await http.SendAsync(
@@ -291,7 +349,7 @@ public class MetricsScrapingWorker(
                 scrapeTimeout.Token);
             if (!resp.IsSuccessStatusCode)
             {
-                MetricsScrapingTelemetry.RecordFailure(deployment, "http_status");
+                RecordFailure(target, "http_status");
                 return;
             }
 
@@ -299,12 +357,14 @@ public class MetricsScrapingWorker(
             if (contentLength > _metricsScrapingOptions.MaxResponseBytes)
             {
                 logger.LogWarning(
-                    "Metrics scrape rejected for {Url}: Content-Length {ContentLength} exceeds " +
+                    "Metrics scrape rejected for function {Function}, source {Source}: " +
+                    "Content-Length {ContentLength} exceeds " +
                     "MaxResponseBytes {MaxResponseBytes}",
-                    url,
+                    target.Function,
+                    target.Source,
                     contentLength,
                     _metricsScrapingOptions.MaxResponseBytes);
-                MetricsScrapingTelemetry.RecordFailure(deployment, "response_too_large");
+                RecordFailure(target, "response_too_large");
                 return;
             }
 
@@ -319,19 +379,29 @@ public class MetricsScrapingWorker(
             if (parsed.Status != PrometheusStreamParseStatus.Success)
             {
                 logger.LogWarning(
-                    "Metrics scrape rejected for {Url}: Reason={Reason}, BytesRead={BytesRead}, " +
+                    "Metrics scrape rejected for function {Function}, source {Source}: " +
+                    "Reason={Reason}, BytesRead={BytesRead}, " +
                     "LinesRead={LinesRead}",
-                    url,
+                    target.Function,
+                    target.Source,
                     parsed.Status,
                     parsed.BytesRead,
                     parsed.LinesRead);
-                MetricsScrapingTelemetry.RecordFailure(deployment, "parse");
+                RecordFailure(target, "parse");
                 return;
             }
 
             if (parsed.Metrics.Count > 0)
-                metricsStore.Add(timestamp, deployment, targetIdentity, parsed.Metrics);
-            MetricsScrapingTelemetry.RecordSuccess(deployment);
+                metricsStore.Add(timestamp, target.Scope, targetIdentity, parsed.Metrics);
+            if (target.IsExternal)
+            {
+                _externalHealthRegistry.RecordSuccess(
+                    target.Scope,
+                    DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    target.IntervalMilliseconds,
+                    parsed.Metrics.Keys);
+            }
+            MetricsScrapingTelemetry.RecordSuccess(target.Function, target.Source);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
@@ -340,20 +410,53 @@ public class MetricsScrapingWorker(
         catch (OperationCanceledException)
         {
             logger.LogWarning(
-                "Metrics scrape timed out after {TimeoutSeconds} seconds for {Url}",
+                "Metrics scrape timed out after {TimeoutSeconds} seconds for function {Function}, source {Source}",
                 _metricsScrapingOptions.RequestTimeoutSeconds,
-                url);
-            MetricsScrapingTelemetry.RecordFailure(deployment, "timeout");
+                target.Function,
+                target.Source);
+            RecordFailure(target, "timeout");
         }
         catch (Exception exception)
         {
-            logger.LogWarning(exception, "metrics scrape error for {Url}", url);
-            MetricsScrapingTelemetry.RecordFailure(deployment, "exception");
+            if (target.IsExternal)
+            {
+                // HttpRequestException messages may contain the full request URI.
+                // Keep configured query parameters out of logs.
+                logger.LogWarning(
+                    "Metrics scrape error for function {Function}, source {Source}: {ErrorType}",
+                    target.Function,
+                    target.Source,
+                    exception.GetType().Name);
+            }
+            else
+            {
+                logger.LogWarning(
+                    exception,
+                    "Metrics scrape error for function {Function}, source {Source}",
+                    target.Function,
+                    target.Source);
+            }
+            RecordFailure(target, "exception");
         }
         finally
         {
-            MetricsScrapingTelemetry.RecordDuration(deployment, Stopwatch.GetElapsedTime(started));
+            MetricsScrapingTelemetry.RecordDuration(
+                target.Function,
+                target.Source,
+                Stopwatch.GetElapsedTime(started));
         }
+    }
+
+    private void RecordFailure(ScrapeTarget target, string reason)
+    {
+        if (target.IsExternal)
+        {
+            _externalHealthRegistry.RecordFailure(
+                target.Scope,
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                target.IntervalMilliseconds);
+        }
+        MetricsScrapingTelemetry.RecordFailure(target.Function, target.Source, reason);
     }
 
     private async Task PersistMetricsSnapshotIfDueAsync(CancellationToken stoppingToken)

--- a/src/SlimFaasBenchmark/BenchmarkTarget.cs
+++ b/src/SlimFaasBenchmark/BenchmarkTarget.cs
@@ -10,7 +10,9 @@ internal static class BenchmarkTarget
     internal const string SentTicksHeader = "X-SlimFaas-Benchmark-Sent-Utc-Ticks";
     internal const string RequestIdHeader = "X-SlimFaas-Benchmark-Request-Id";
 
-    public static async Task<int> RunAsync(CommandArguments arguments)
+    public static async Task<int> RunAsync(
+        CommandArguments arguments,
+        CancellationToken cancellationToken = default)
     {
         int port = ResolvePort(arguments);
         var observations = new ConcurrentDictionary<string, ObservationAccumulator>(StringComparer.Ordinal);
@@ -102,7 +104,7 @@ internal static class BenchmarkTarget
             });
 
         Console.WriteLine($"SlimFaas benchmark target listening on http://127.0.0.1:{port}");
-        await app.RunAsync();
+        await app.RunAsync(cancellationToken);
         return 0;
     }
 

--- a/src/SlimFaasBenchmark/BenchmarkTarget.cs
+++ b/src/SlimFaasBenchmark/BenchmarkTarget.cs
@@ -16,6 +16,7 @@ internal static class BenchmarkTarget
         var observations = new ConcurrentDictionary<string, ObservationAccumulator>(StringComparer.Ordinal);
         long requestCount = 0;
         long lastScaleWorkTicks = 0;
+        long externalScalePressure = 0;
 
         WebApplicationBuilder builder = WebApplication.CreateSlimBuilder();
         builder.Logging.ClearProviders();
@@ -36,8 +37,17 @@ internal static class BenchmarkTarget
                     $"# TYPE slimfaas_benchmark_target_requests_total counter\n" +
                     $"slimfaas_benchmark_target_requests_total {Volatile.Read(ref requestCount)}\n" +
                     $"# TYPE slimfaas_benchmark_scale_pressure gauge\n" +
-                    $"slimfaas_benchmark_scale_pressure {scalePressure}\n"),
+                    $"slimfaas_benchmark_scale_pressure {scalePressure}\n" +
+                    $"# TYPE slimfaas_benchmark_external_pressure gauge\n" +
+                    $"slimfaas_benchmark_external_pressure {Volatile.Read(ref externalScalePressure)}\n"),
                 "text/plain; version=0.0.4");
+        });
+        app.MapPut("/benchmark/external-pressure/{value:long}", (long value) =>
+        {
+            if (value < 0)
+                return Results.BadRequest("pressure must be greater than or equal to zero");
+            Interlocked.Exchange(ref externalScalePressure, value);
+            return Results.NoContent();
         });
         app.MapGet("/benchmark/observations/{runId}", (string runId) =>
         {

--- a/tests/SlimFaas.Tests/Benchmark/AsyncBenchmarkTests.cs
+++ b/tests/SlimFaas.Tests/Benchmark/AsyncBenchmarkTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using SlimFaasBenchmark;
@@ -6,6 +8,46 @@ namespace SlimFaas.Tests.Benchmark;
 
 public sealed class AsyncBenchmarkTests
 {
+    [Fact]
+    public async Task Target_external_pressure_endpoint_controls_exported_metric()
+    {
+        int port = GetAvailablePort();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        Task<int> target = BenchmarkTarget.RunAsync(
+            CommandArguments.Parse(["--port", port.ToString()]),
+            cancellation.Token);
+        using var client = new HttpClient
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{port}"),
+            Timeout = TimeSpan.FromSeconds(2)
+        };
+
+        try
+        {
+            await WaitUntilHealthyAsync(client, cancellation.Token);
+
+            using HttpResponseMessage invalid = await client.PutAsync(
+                "/benchmark/external-pressure/-1",
+                content: null,
+                cancellation.Token);
+            Assert.Equal(HttpStatusCode.BadRequest, invalid.StatusCode);
+
+            using HttpResponseMessage updated = await client.PutAsync(
+                "/benchmark/external-pressure/4",
+                content: null,
+                cancellation.Token);
+            Assert.Equal(HttpStatusCode.NoContent, updated.StatusCode);
+
+            string metrics = await client.GetStringAsync("/metrics", cancellation.Token);
+            Assert.Contains("slimfaas_benchmark_external_pressure 4", metrics, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await cancellation.CancelAsync();
+            Assert.Equal(0, await target.WaitAsync(TimeSpan.FromSeconds(5)));
+        }
+    }
+
     [Fact]
     public void Statistics_compute_interpolated_percentiles_and_mean_inputs()
     {
@@ -204,6 +246,34 @@ public sealed class AsyncBenchmarkTests
             [],
             scaling,
             []);
+    }
+
+    private static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static async Task WaitUntilHealthyAsync(HttpClient client, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                using HttpResponseMessage response = await client.GetAsync("/health", cancellationToken);
+                if (response.IsSuccessStatusCode)
+                    return;
+            }
+            catch (HttpRequestException)
+            {
+                // Kestrel is still starting.
+            }
+
+            await Task.Delay(25, cancellationToken);
+        }
     }
 
     private static LatencyAggregateResult Row(

--- a/tests/SlimFaas.Tests/Endpoints/DebugPromQlEndpointTests.cs
+++ b/tests/SlimFaas.Tests/Endpoints/DebugPromQlEndpointTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SlimFaas.Kubernetes;
+
+namespace SlimFaas.Tests.Endpoints;
+
+public sealed class DebugPromQlEndpointTests
+{
+    [Fact]
+    public async Task EvaluateWithSourceUsesTheConfiguredExternalScope()
+    {
+        long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        const string function = "worker";
+        const string source = "queue";
+        string scope = MetricsSourceScope.ForExternal(function, source);
+        PromQlMiniEvaluator.SnapshotProvider snapshots = () =>
+            new Dictionary<long, IReadOnlyDictionary<string,
+                IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>>>>
+            {
+                [now] = new Dictionary<string,
+                    IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>>>
+                {
+                    [function] = TargetWithMetric(99),
+                    [scope] = TargetWithMetric(3)
+                }
+            };
+        var health = new ExternalMetricsSourceHealthRegistry();
+        health.RecordSuccess(scope, now, 1_000, ["queue_depth"]);
+        var deployment = new DeploymentInformation(
+            function,
+            "default",
+            [],
+            new SlimFaasConfiguration(),
+            Replicas: 0,
+            Scale: new ScaleConfig
+            {
+                Sources = [new ScaleSource(source, "https://queue.example.test/metrics")],
+                Triggers = [new ScaleTrigger(Query: "queue_depth", Threshold: 1, Source: source)]
+            });
+
+        using IHost host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder => webBuilder
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddSingleton(new PromQlMiniEvaluator(snapshots));
+                    services.AddSingleton<IMetricsScrapingGuard, MetricsScrapingGuard>();
+                    services.AddSingleton<IRequestedMetricsRegistry, RequestedMetricsRegistry>();
+                    services.AddSingleton<IExternalMetricsSourceHealthRegistry>(health);
+                    services.AddSingleton<IReplicasService>(new TestReplicasService(deployment));
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints => endpoints.MapDebugRoutes());
+                }))
+            .StartAsync();
+        using var body = new StringContent(
+            $$"""{"query":"queue_depth","deployment":"{{function}}","source":"{{source}}","nowUnixSeconds":{{now}}}""",
+            Encoding.UTF8,
+            "application/json");
+
+        HttpResponseMessage response = await host.GetTestClient().PostAsync("/debug/promql/eval", body);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        using JsonDocument json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(3, json.RootElement.GetProperty("value").GetDouble());
+    }
+
+    private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>> TargetWithMetric(
+        double value) =>
+        new Dictionary<string, IReadOnlyDictionary<string, double>>
+        {
+            ["target"] = new Dictionary<string, double> { ["queue_depth"] = value }
+        };
+
+    private sealed class TestReplicasService(DeploymentInformation deployment) : IReplicasService
+    {
+        public DeploymentsInformations Deployments { get; } = new(
+            [deployment],
+            new SlimFaasDeploymentInformation(1, []),
+            []);
+
+        public Task<DeploymentsInformations> SyncDeploymentsAsync(string kubeNamespace) =>
+            Task.FromResult(Deployments);
+
+        public Task CheckScaleAsync(string kubeNamespace) => Task.CompletedTask;
+    }
+}

--- a/tests/SlimFaas.Tests/Endpoints/FunctionStatusMappingTests.cs
+++ b/tests/SlimFaas.Tests/Endpoints/FunctionStatusMappingTests.cs
@@ -45,6 +45,11 @@ public class FunctionStatusMappingTests
                     WakeUp = new List<string> { "08:00" },
                     ScaleDownTimeout = new List<ScaleDownTimeout>()
                 }
+            },
+            Scale: new ScaleConfig
+            {
+                Sources = [new ScaleSource("queue", "https://metrics.example.test/metrics")],
+                Triggers = [new ScaleTrigger(Query: "queue_depth", Threshold: 1, Source: "queue")]
             }
         );
 
@@ -85,6 +90,10 @@ public class FunctionStatusMappingTests
         // Schedule
         Assert.NotNull(result.Schedule);
         Assert.Single(result.Schedule.Default!.WakeUp);
+
+        // External autoscaling source and trigger remain visible in detailed status.
+        Assert.Equal("queue", Assert.Single(result.Scale!.Sources).Name);
+        Assert.Equal("queue", Assert.Single(result.Scale.Triggers).Source);
 
         // Pods
         Assert.Equal(2, result.Pods.Count);
@@ -207,4 +216,3 @@ public class FunctionStatusMappingTests
         Assert.Equal(1, result.NumberRequested);
     }
 }
-

--- a/tests/SlimFaas.Tests/Kubernetes/AutoScalerTests.cs
+++ b/tests/SlimFaas.Tests/Kubernetes/AutoScalerTests.cs
@@ -361,14 +361,13 @@ public sealed class AutoScalerTests
 
 
     [Fact]
-    public void FromZero_WithPositiveMetric_ShouldScaleFromOne()
+    public void FromZero_WithLocalResidualMetric_ShouldRemainAtZero()
     {
         var scaler = CreateAutoScaler();
         string key = "func";
         long now = 1_000;
 
-        // current = 0 → effectiveCurrent = 1
-        // metric = 10, thr = 5 → ratio = 2 → desired = ceil(1 * 2) = 2
+        // Pod-local triggers are ignored at zero; only an external source can wake.
         var cfg = MakeSimpleScaleConfig(metricValue: 10, threshold: 5);
 
         var desired = scaler.ComputeDesiredReplicas(
@@ -379,7 +378,7 @@ public sealed class AutoScalerTests
             maxReplicas: 100,
             nowUnixSeconds: now);
 
-        Assert.Equal(2, desired);
+        Assert.Equal(0, desired);
     }
 
     [Fact]

--- a/tests/SlimFaas.Tests/Kubernetes/ExternalMetricsAutoScalerTests.cs
+++ b/tests/SlimFaas.Tests/Kubernetes/ExternalMetricsAutoScalerTests.cs
@@ -1,0 +1,197 @@
+using SlimFaas.Kubernetes;
+
+namespace SlimFaas.Tests.Kubernetes;
+
+public sealed class ExternalMetricsAutoScalerTests
+{
+    private static readonly ScaleBehavior UnlimitedBehavior = new()
+    {
+        ScaleUp = new ScaleDirectionBehavior { Policies = [] },
+        ScaleDown = new ScaleDirectionBehavior { Policies = [] }
+    };
+
+    [Fact]
+    public void ExternalSource_WakesFromZeroAndAdjustsRunningReplicas()
+    {
+        const long now = 1_000;
+        const string function = "worker";
+        const string source = "queue";
+        string scope = MetricsSourceScope.ForExternal(function, source);
+        var values = new Dictionary<string, double> { [scope] = 2 };
+        var health = Healthy(scope, now, "queue_depth");
+        var scaler = CreateScaler(values, now, health);
+        ScaleConfig config = Config(new ScaleTrigger(
+            ScaleMetricType.AverageValue,
+            "queue",
+            "queue_depth",
+            1,
+            source));
+
+        Assert.Equal(2, scaler.ComputeDesiredReplicas(function, config, 0, 0, 10, now));
+
+        values[scope] = 4;
+        health.RecordSuccess(scope, now + 1, 1_000, ["queue_depth"]);
+        Assert.Equal(4, scaler.ComputeDesiredReplicas(function, config, 2, 0, 10, now + 1));
+    }
+
+    [Fact]
+    public void TriggersUseIsolatedLocalAndExternalScopesAndAggregateByMaximum()
+    {
+        const long now = 2_000;
+        const string function = "worker";
+        string queueScope = MetricsSourceScope.ForExternal(function, "queue");
+        string brokerScope = MetricsSourceScope.ForExternal(function, "broker");
+        var values = new Dictionary<string, double>
+        {
+            [function] = 1,
+            [queueScope] = 3,
+            [brokerScope] = 5
+        };
+        var health = Healthy(queueScope, now, "pressure");
+        health.RecordSuccess(brokerScope, now, 1_000, ["pressure"]);
+        var scaler = CreateScaler(values, now, health);
+        ScaleConfig config = Config(
+            new ScaleTrigger(ScaleMetricType.AverageValue, "local", "pressure", 1),
+            new ScaleTrigger(ScaleMetricType.AverageValue, "queue", "pressure", 1, "queue"),
+            new ScaleTrigger(ScaleMetricType.AverageValue, "broker", "pressure", 1, "broker"));
+
+        Assert.Equal(5, scaler.ComputeDesiredReplicas(function, config, 2, 0, 10, now));
+    }
+
+    [Fact]
+    public void LocalResidualMetricCannotWakeAFunctionFromZero()
+    {
+        const long now = 3_000;
+        const string function = "worker";
+        var scaler = CreateScaler(new Dictionary<string, double> { [function] = 10 }, now);
+        ScaleConfig config = Config(
+            new ScaleTrigger(ScaleMetricType.AverageValue, "local", "pressure", 1));
+
+        Assert.Equal(0, scaler.ComputeDesiredReplicas(function, config, 0, 0, 10, now));
+    }
+
+    [Theory]
+    [InlineData("failed")]
+    [InlineData("missing")]
+    [InlineData("stale")]
+    public void InvalidExternalSourceBlocksScaleDown(string invalidState)
+    {
+        const long now = 4_000;
+        const string function = "worker";
+        string scope = MetricsSourceScope.ForExternal(function, "queue");
+        var health = new ExternalMetricsSourceHealthRegistry();
+        if (invalidState == "failed")
+        {
+            health.RecordSuccess(scope, now, 1_000, ["queue_depth"]);
+            health.RecordFailure(scope, now, 1_000);
+        }
+        else if (invalidState == "missing")
+        {
+            health.RecordSuccess(scope, now, 1_000, ["another_metric"]);
+        }
+        else
+        {
+            health.RecordSuccess(scope, now - 4, 1_000, ["queue_depth"]);
+        }
+
+        var scaler = CreateScaler(new Dictionary<string, double> { [scope] = 0 }, now, health);
+        ScaleConfig config = Config(new ScaleTrigger(
+            ScaleMetricType.AverageValue,
+            "queue",
+            "queue_depth",
+            1,
+            "queue"));
+
+        Assert.Equal(4, scaler.ComputeDesiredReplicas(function, config, 4, 0, 10, now));
+    }
+
+    [Fact]
+    public void InvalidExternalTriggerDoesNotPreventAnotherTriggerFromScalingUp()
+    {
+        const long now = 5_000;
+        const string function = "worker";
+        string healthyScope = MetricsSourceScope.ForExternal(function, "healthy");
+        var health = Healthy(healthyScope, now, "pressure");
+        var scaler = CreateScaler(new Dictionary<string, double> { [healthyScope] = 6 }, now, health);
+        ScaleConfig config = Config(
+            new ScaleTrigger(ScaleMetricType.AverageValue, "healthy", "pressure", 1, "healthy"),
+            new ScaleTrigger(ScaleMetricType.AverageValue, "failed", "pressure", 1, "failed"));
+
+        Assert.Equal(6, scaler.ComputeDesiredReplicas(function, config, 2, 0, 10, now));
+    }
+
+    [Fact]
+    public void ExternalTriggerHonorsReplicaMaxAndScaleUpPolicy()
+    {
+        const long now = 6_000;
+        const string function = "worker";
+        string scope = MetricsSourceScope.ForExternal(function, "queue");
+        var health = Healthy(scope, now, "queue_depth");
+        var scaler = CreateScaler(new Dictionary<string, double> { [scope] = 100 }, now, health);
+        ScaleConfig config = Config(new ScaleTrigger(
+            ScaleMetricType.AverageValue,
+            "queue",
+            "queue_depth",
+            1,
+            "queue")) with
+        {
+            ReplicaMax = 8,
+            Behavior = new ScaleBehavior
+            {
+                ScaleUp = new ScaleDirectionBehavior
+                {
+                    Policies = [new ScalePolicy(ScalePolicyType.Pods, 2, 0)]
+                },
+                ScaleDown = new ScaleDirectionBehavior { Policies = [] }
+            }
+        };
+
+        Assert.Equal(5, scaler.ComputeDesiredReplicas(function, config, 3, 0, config.ReplicaMax, now));
+    }
+
+    private static ScaleConfig Config(params ScaleTrigger[] triggers) => new()
+    {
+        Triggers = triggers,
+        Behavior = UnlimitedBehavior
+    };
+
+    private static ExternalMetricsSourceHealthRegistry Healthy(
+        string scope,
+        long now,
+        params string[] names)
+    {
+        var health = new ExternalMetricsSourceHealthRegistry();
+        health.RecordSuccess(scope, now, 1_000, names);
+        return health;
+    }
+
+    private static AutoScaler CreateScaler(
+        IDictionary<string, double> valuesByScope,
+        long timestamp,
+        IExternalMetricsSourceHealthRegistry? health = null)
+    {
+        IReadOnlyDictionary<long, IReadOnlyDictionary<string,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>>>> SnapshotProvider()
+        {
+            var scopes = valuesByScope.ToDictionary(
+                static pair => pair.Key,
+                static pair => (IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>>)
+                    new Dictionary<string, IReadOnlyDictionary<string, double>>
+                    {
+                        ["target"] = new Dictionary<string, double> { ["pressure"] = pair.Value, ["queue_depth"] = pair.Value }
+                    },
+                StringComparer.Ordinal);
+            return new Dictionary<long, IReadOnlyDictionary<string,
+                IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>>>>
+            {
+                [timestamp] = scopes
+            };
+        }
+
+        return new AutoScaler(
+            new PromQlMiniEvaluator(SnapshotProvider),
+            new InMemoryAutoScalerStore(),
+            logger: null,
+            externalHealthRegistry: health);
+    }
+}

--- a/tests/SlimFaas.Tests/Kubernetes/FunctionMetadataParserTests.cs
+++ b/tests/SlimFaas.Tests/Kubernetes/FunctionMetadataParserTests.cs
@@ -111,4 +111,79 @@ public sealed class FunctionMetadataParserTests
         Assert.Null(metadata.Scale);
         Assert.NotNull(metadata.Schedule);
     }
+
+    [Fact]
+    public void Parse_NormalizesNamedExternalSourcesAndTriggerReferences()
+    {
+        FunctionMetadata metadata = FunctionMetadataParser.Parse(
+            new Dictionary<string, string>
+            {
+                [FunctionAnnotationNames.Function] = "true",
+                [FunctionAnnotationNames.Scale] =
+                    """
+                    {
+                      "Sources": [{"Name":" redis ","Url":" https://metrics.example.test/openmetrics?tenant=one "}],
+                      "Triggers": [{"MetricName":"queue","Query":"queue_depth","Threshold":1,"Source":" redis "}]
+                    }
+                    """
+            },
+            "function");
+
+        ScaleConfig scale = Assert.IsType<ScaleConfig>(metadata.Scale);
+        ScaleSource source = Assert.Single(scale.Sources);
+        Assert.Equal("redis", source.Name);
+        Assert.Equal("https://metrics.example.test/openmetrics?tenant=one", source.Url);
+        Assert.Equal("redis", Assert.Single(scale.Triggers).Source);
+    }
+
+    [Theory]
+    [InlineData("ftp://metrics.example.test/metrics")]
+    [InlineData("/metrics")]
+    [InlineData("https://user:secret@metrics.example.test/metrics")]
+    [InlineData("https://metrics.example.test/metrics#private")]
+    public void NormalizeScaleConfig_RejectsInvalidExternalSourceUrls(string url)
+    {
+        var scale = new ScaleConfig
+        {
+            Sources = [new ScaleSource("source", url)]
+        };
+
+        Assert.Throws<FormatException>(() => FunctionMetadataParser.NormalizeScaleConfig(scale));
+    }
+
+    [Fact]
+    public void NormalizeScaleConfig_RejectsDuplicateSourceNamesCaseSensitively()
+    {
+        var duplicate = new ScaleConfig
+        {
+            Sources =
+            [
+                new ScaleSource("redis", "http://redis-one/metrics"),
+                new ScaleSource("redis", "http://redis-two/metrics")
+            ]
+        };
+        var distinctCase = duplicate with
+        {
+            Sources =
+            [
+                new ScaleSource("redis", "http://redis-one/metrics"),
+                new ScaleSource("Redis", "http://redis-two/metrics")
+            ]
+        };
+
+        Assert.Throws<FormatException>(() => FunctionMetadataParser.NormalizeScaleConfig(duplicate));
+        Assert.Equal(2, FunctionMetadataParser.NormalizeScaleConfig(distinctCase).Sources.Count);
+    }
+
+    [Fact]
+    public void NormalizeScaleConfig_RejectsUnknownTriggerSource()
+    {
+        var scale = new ScaleConfig
+        {
+            Sources = [new ScaleSource("known", "http://metrics/metrics")],
+            Triggers = [new ScaleTrigger(Query: "queue_depth", Threshold: 1, Source: "unknown")]
+        };
+
+        Assert.Throws<FormatException>(() => FunctionMetadataParser.NormalizeScaleConfig(scale));
+    }
 }

--- a/tests/SlimFaas.Tests/ReplicasScaleWorkerShould.cs
+++ b/tests/SlimFaas.Tests/ReplicasScaleWorkerShould.cs
@@ -615,5 +615,95 @@ public class ReplicasScaleWorkerShould
             Times.Never);
     }
 
+    [Fact]
+    public async Task ExternalMetricCanWakeDeploymentFromZeroWithoutHttpTraffic()
+    {
+        DateTime now = DateTime.UtcNow;
+        long timestamp = new DateTimeOffset(now).ToUnixTimeSeconds();
+        const string function = "external-worker";
+        const string source = "queue";
+        string scope = MetricsSourceScope.ForExternal(function, source);
+        PromQlMiniEvaluator.SnapshotProvider snapshotProvider = () =>
+            new Dictionary<long, IReadOnlyDictionary<string,
+                IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>>>>
+            {
+                [timestamp] = new Dictionary<string,
+                    IReadOnlyDictionary<string, IReadOnlyDictionary<string, double>>>
+                {
+                    [scope] = new Dictionary<string, IReadOnlyDictionary<string, double>>
+                    {
+                        ["source"] = new Dictionary<string, double> { ["queue_depth"] = 2 }
+                    }
+                }
+            };
+        var health = new ExternalMetricsSourceHealthRegistry();
+        health.RecordSuccess(scope, timestamp, 1_000, ["queue_depth"]);
+        var autoScaler = new AutoScaler(
+            new PromQlMiniEvaluator(snapshotProvider),
+            new InMemoryAutoScalerStore(),
+            externalHealthRegistry: health);
+        var deployment = new DeploymentInformation(
+            function,
+            "default",
+            [],
+            new SlimFaasConfiguration(),
+            Replicas: 0,
+            ReplicasAtStart: 1,
+            ReplicasMin: 0,
+            TimeoutSecondBeforeSetReplicasMin: 0,
+            Scale: new ScaleConfig
+            {
+                ReplicaMax = 4,
+                Sources = [new ScaleSource(source, "http://queue/metrics")],
+                Triggers =
+                [
+                    new ScaleTrigger(
+                        ScaleMetricType.AverageValue,
+                        "queue",
+                        "queue_depth",
+                        1,
+                        source)
+                ],
+                Behavior = new ScaleBehavior
+                {
+                    ScaleUp = new ScaleDirectionBehavior { Policies = [] },
+                    ScaleDown = new ScaleDirectionBehavior { Policies = [] }
+                }
+            });
+        var deployments = new DeploymentsInformations(
+            [deployment],
+            new SlimFaasDeploymentInformation(1, []),
+            []);
+        var kubernetesService = new Mock<IKubernetesService>();
+        kubernetesService.Setup(service => service.ListFunctionsAsync(
+                "default",
+                It.IsAny<DeploymentsInformations>()))
+            .ReturnsAsync(deployments);
+        var expected = new ReplicaRequest(
+            Replicas: 2,
+            Deployment: function,
+            Namespace: "default",
+            PodType: PodType.Deployment);
+        kubernetesService.Setup(service => service.ScaleAsync(expected)).ReturnsAsync(expected);
+        var history = new HistoryHttpMemoryService();
+        history.SetTickLastCall(function, now.AddMinutes(-1).Ticks);
+        var replicasService = new ReplicasService(
+            kubernetesService.Object,
+            history,
+            autoScaler,
+            Mock.Of<ILogger<ReplicasService>>(),
+            Mock.Of<IRequestedMetricsRegistry>(),
+            Microsoft.Extensions.Options.Options.Create(new SlimFaasOptions
+            {
+                PodScaledUpByDefaultWhenInfrastructureHasNeverCalled = false
+            }),
+            () => now);
+
+        await replicasService.SyncDeploymentsAsync("default");
+        await replicasService.CheckScaleAsync("default");
+
+        kubernetesService.Verify(service => service.ScaleAsync(expected), Times.Once);
+    }
+
 
 }

--- a/tests/SlimFaas.Tests/Workers/MetricsScrapingWorkerTests.cs
+++ b/tests/SlimFaas.Tests/Workers/MetricsScrapingWorkerTests.cs
@@ -197,6 +197,34 @@ namespace SlimFaas.Tests.Workers
                 Pods: new List<PodInformation>());
         }
 
+        private static DeploymentsInformations BuildExternalDeployments(
+            params (string Function, string Source, string Url, int TriggerCount)[] definitions)
+        {
+            var functions = definitions.Select(definition => new DeploymentInformation(
+                Deployment: definition.Function,
+                Namespace: "ns",
+                Pods: [],
+                Configuration: new SlimFaasConfiguration(),
+                Replicas: 0,
+                Scale: new ScaleConfig
+                {
+                    ScrapeIntervalMilliseconds = 1_000,
+                    Sources = [new ScaleSource(definition.Source, definition.Url)],
+                    Triggers = Enumerable.Range(0, definition.TriggerCount)
+                        .Select(index => new ScaleTrigger(
+                            MetricName: $"metric-{index}",
+                            Query: "external_pressure",
+                            Threshold: 1,
+                            Source: definition.Source))
+                        .ToList()
+                })).ToList();
+
+            return new DeploymentsInformations(
+                functions,
+                new SlimFaasDeploymentInformation(0, []),
+                []);
+        }
+
         private sealed class MapHttpHandler : HttpMessageHandler
         {
             private readonly ConcurrentDictionary<string, (HttpStatusCode code, string body)> _map;
@@ -294,7 +322,8 @@ namespace SlimFaas.Tests.Workers
             bool scrapingEnabled = true,
             int delayMs = 10_000,
             MetricsScrapingOptions? metricsScrapingOptions = null,
-            IMasterService? masterService = null) // le scraping se fait avant le premier Delay
+            IMasterService? masterService = null,
+            IExternalMetricsSourceHealthRegistry? healthRegistry = null) // le scraping se fait avant le premier Delay
         {
             // IReplicasService
             var replicas = new Mock<IReplicasService>();
@@ -337,7 +366,8 @@ namespace SlimFaas.Tests.Workers
                 requestedMetricsRegistry: requestedMetricsRegistry,
                 logger: logger,
                 slimFaasOptions: slimFaasOptions,
-                delay: delayMs
+                delay: delayMs,
+                externalHealthRegistry: healthRegistry
             );
         }
 
@@ -1155,6 +1185,167 @@ namespace SlimFaas.Tests.Workers
             Assert.NotEmpty(hydratedStore.Snapshot());
             Assert.True(db.GetCount("metrics:store:version") >= 2);
             Assert.Equal(1, db.GetCount("metrics:store"));
+        }
+
+        [Fact]
+        public async Task ExternalHttpsSourcesAreScrapedAtZeroReplicasOncePerSourceAndRemainIsolated()
+        {
+            const string urlA = "https://metrics-a.example.test/metrics?tenant=one";
+            const string urlB = "https://metrics-b.example.test/metrics";
+            var deployments = BuildExternalDeployments(
+                ("function-a", "queue", urlA, 2),
+                ("function-b", "queue", urlB, 1));
+            var requestCounts = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+            var handler = new DelegateHttpHandler((request, _) =>
+            {
+                string url = request.RequestUri!.AbsoluteUri;
+                requestCounts.AddOrUpdate(url, 1, static (_, count) => count + 1);
+                string value = url == urlA ? "2" : "7";
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        $"external_pressure {value}\n",
+                        Encoding.UTF8,
+                        "text/plain")
+                });
+            });
+            using var http = new HttpClient(handler);
+            var store = CreateStore(out var registry, "external_pressure");
+            var health = new ExternalMetricsSourceHealthRegistry();
+            var worker = NewWorker(
+                deployments,
+                http,
+                isMaster: true,
+                store,
+                registry,
+                delayMs: 10_000,
+                healthRegistry: health);
+
+            await StartRunOnceAndStopAsync(worker);
+
+            Assert.Equal(1, requestCounts[urlA]);
+            Assert.Equal(1, requestCounts[urlB]);
+            var snapshot = store.Snapshot();
+            long timestamp = snapshot.Keys.Single();
+            string scopeA = MetricsSourceScope.ForExternal("function-a", "queue");
+            string scopeB = MetricsSourceScope.ForExternal("function-b", "queue");
+            Assert.Equal(2, snapshot[timestamp][scopeA]["source"]["external_pressure"]);
+            Assert.Equal(7, snapshot[timestamp][scopeB]["source"]["external_pressure"]);
+            Assert.True(health.IsHealthy(scopeA, timestamp, new HashSet<string> { "external_pressure" }, out _));
+            Assert.True(health.IsHealthy(scopeB, timestamp, new HashSet<string> { "external_pressure" }, out _));
+        }
+
+        [Fact]
+        public async Task ExternalSourceFailureImmediatelyInvalidatesPreviouslyScrapedMetrics()
+        {
+            const string url = "http://metrics.example.test/metrics";
+            var deployments = BuildExternalDeployments(("function", "queue", url, 1));
+            var requestCount = 0;
+            var handler = new DelegateHttpHandler((_, _) =>
+            {
+                int current = Interlocked.Increment(ref requestCount);
+                return Task.FromResult(current == 1
+                    ? new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("external_pressure 4\n", Encoding.UTF8, "text/plain")
+                    }
+                    : new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    {
+                        Content = new StringContent(string.Empty)
+                    });
+            });
+            using var http = new HttpClient(handler);
+            var store = CreateStore(out var registry, "external_pressure");
+            var health = new ExternalMetricsSourceHealthRegistry();
+            var worker = NewWorker(
+                deployments,
+                http,
+                isMaster: true,
+                store,
+                registry,
+                delayMs: 20,
+                healthRegistry: health);
+            string scope = MetricsSourceScope.ForExternal("function", "queue");
+
+            await RunUntilAndStopAsync(
+                worker,
+                () => Volatile.Read(ref requestCount) >= 2 &&
+                      health.TryGet(scope, out ExternalMetricsSourceHealth? state) &&
+                      state is { LastAttemptSucceeded: false },
+                TimeSpan.FromSeconds(5));
+
+            Assert.Contains(store.Snapshot().Values, bucket => bucket.ContainsKey(scope));
+            Assert.False(health.IsHealthy(
+                scope,
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                new HashSet<string> { "external_pressure" },
+                out string reason));
+            Assert.Equal("last_scrape_failed", reason);
+        }
+
+        [Fact]
+        public async Task ExternalSourceUsesTheConfiguredResponseSizeLimit()
+        {
+            const string url = "https://metrics.example.test/metrics";
+            var deployments = BuildExternalDeployments(("function", "queue", url, 1));
+            using var http = new HttpClient(new DelegateHttpHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "external_pressure 123456789\n",
+                        Encoding.UTF8,
+                        "text/plain")
+                })));
+            var store = CreateStore(out var registry, "external_pressure");
+            var health = new ExternalMetricsSourceHealthRegistry();
+            var worker = NewWorker(
+                deployments,
+                http,
+                isMaster: true,
+                store,
+                registry,
+                delayMs: 10_000,
+                metricsScrapingOptions: new MetricsScrapingOptions { MaxResponseBytes = 8 },
+                healthRegistry: health);
+            string scope = MetricsSourceScope.ForExternal("function", "queue");
+
+            await StartRunOnceAndStopAsync(worker);
+
+            Assert.Empty(store.Snapshot());
+            Assert.True(health.TryGet(scope, out ExternalMetricsSourceHealth? state));
+            Assert.False(state!.LastAttemptSucceeded);
+        }
+
+        [Fact]
+        public async Task ExternalSourceUsesTheConfiguredRequestTimeout()
+        {
+            const string url = "https://metrics.example.test/metrics";
+            var deployments = BuildExternalDeployments(("function", "queue", url, 1));
+            using var http = new HttpClient(new DelegateHttpHandler(async (_, cancellationToken) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }));
+            var store = CreateStore(out var registry, "external_pressure");
+            var health = new ExternalMetricsSourceHealthRegistry();
+            var worker = NewWorker(
+                deployments,
+                http,
+                isMaster: true,
+                store,
+                registry,
+                delayMs: 10_000,
+                metricsScrapingOptions: new MetricsScrapingOptions { RequestTimeoutSeconds = 1 },
+                healthRegistry: health);
+            string scope = MetricsSourceScope.ForExternal("function", "queue");
+
+            await RunUntilAndStopAsync(
+                worker,
+                () => health.TryGet(scope, out ExternalMetricsSourceHealth? state) &&
+                      state is { LastAttemptSucceeded: false },
+                TimeSpan.FromSeconds(5));
+
+            Assert.Empty(store.Snapshot());
         }
     }
 }


### PR DESCRIPTION
## Summary

- add named HTTP/HTTPS OpenMetrics sources to `SlimFaas/Scale` and isolate stored series by function/source
- allow external triggers to wake functions from zero while ignoring residual pod-local metrics at zero
- make external trigger evaluation fail-safe on scrape errors, missing/non-finite metrics, and stale data
- expose source-aware debug evaluation, bounded telemetry labels, source availability, detailed status, and dashboard labels
- update the local/Kubernetes/Kafka examples and user documentation
- add a manual native-local integration scenario without changing GitHub Actions

## Safety and compatibility

- `Triggers[].Source` is optional and appended to the C# positional record
- triggers without `Source` retain pod-local scraping and historical storage keys
- external URLs require absolute HTTP/HTTPS, with no credentials or fragments
- query parameters and URLs are not emitted in logs or metric labels
- no dependency or lockfile changes

## Validation

- `dotnet test --no-restore -p:SkipClientAppBuild=true`
  - SlimFaas.Tests: 899 passed
  - SlimData.Tests: 176 passed
  - SlimFaasMcp.Tests: 79 passed
  - SlimFaasKafka.Tests: 9 passed
- `.bin/slimfaas-local-external-metrics-test.sh`
  - passed `0 -> 2 -> 4 -> 0` using `benchmarks/slimfaas.local.external-metrics.yaml`
- `(cd src/SlimFaasSite && pnpm install --frozen-lockfile && pnpm build)`
- `(cd src/SlimFaas/ClientApp && npm run build)`
- `dotnet publish src/SlimFaas/SlimFaas.csproj -c Release -r osx-arm64 --self-contained true -p:SkipClientAppBuild=true --no-restore`
- quick `.bin/slimfaas-local-benchmark.sh` smoke profile, including scale-to-zero/scale-out: passed with no failed requests
- [GitHub Actions](https://github.com/SlimPlanet/SlimFaas/actions/runs/33749220860): Unit Tests, SonarCloud Quality Gate, Docker builds, AOT matrices, DCO, and FOSSA passed

Closes #324
