### PR TITLE
fix: release job concurrency slots before TTL cleanup

### DIFF
--- a/.bin/test-local-job-concurrency.py
+++ b/.bin/test-local-job-concurrency.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Verify that retained local jobs release concurrency slots before TTL cleanup.
+
+Build SlimFaas and FibonacciBatch first, then run this script from any directory.
+Uses only the Python standard library, temporary state, and loopback ports.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def yaml_mapping(mapping, indent=0):
+    """Emit this fixture's block mappings with JSON-quoted scalars and lists."""
+    for key, value in mapping.items():
+        prefix = " " * indent + json.dumps(key) + ":"
+        if isinstance(value, dict):
+            yield prefix
+            yield from yaml_mapping(value, indent + 2)
+        else:
+            yield prefix + " " + json.dumps(value)
+
+
+def available_ports(count):
+    # Reserve all ports together so no two allocations in this test coincide.
+    sockets = []
+    try:
+        for _ in range(count):
+            listener = socket.socket()
+            listener.bind(("127.0.0.1", 0))
+            sockets.append(listener)
+        return [listener.getsockname()[1] for listener in sockets]
+    finally:
+        for listener in sockets:
+            listener.close()
+
+
+def stop(process):
+    if process.poll() is not None:
+        return
+    process.send_signal(signal.CTRL_BREAK_EVENT if os.name == "nt" else signal.SIGTERM)
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        if os.name == "nt":
+            subprocess.run(["taskkill", "/PID", str(process.pid), "/T", "/F"], check=False)
+        else:
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", type=Path,
+                        default=ROOT / "src/SlimFaas/bin/Debug/net10.0/SlimFaas.dll")
+    parser.add_argument("--batch", type=Path,
+                        default=ROOT / "src/FibonacciBatch/bin/Debug/net10.0/FibonacciBatch.dll")
+    args = parser.parse_args()
+    runtime, batch = args.runtime.resolve(), args.batch.resolve()
+    for path in (runtime, batch):
+        if not path.is_file():
+            parser.error(f"Build the workload first; missing {path}")
+    dotnet = os.environ.get("DOTNET_HOST_PATH", "dotnet")
+    runtime_command = [dotnet, str(runtime)] if runtime.suffix == ".dll" else [str(runtime)]
+    batch_command = [dotnet, str(batch)] if batch.suffix == ".dll" else [str(batch)]
+    entrypoint, node, raft = available_ports(3)
+
+    with tempfile.TemporaryDirectory(prefix="slimfaas-job-concurrency-") as temporary:
+        root = Path(temporary)
+        manifest = {
+            "schemaVersion": 1,
+            "name": "job-concurrency",
+            "cluster": {"nodes": 1, "entrypointPort": entrypoint,
+                        "nodeHttpPortBase": node, "raftPortBase": raft},
+            "state": {"mode": "persistent", "directory": str(root / "state")},
+            "jobs": {
+                name: {
+                    "command": batch_command,
+                    "workingDirectory": str(batch.parent),
+                    "annotations": {"SlimFaas/Job": "true", "SlimFaas/DefaultVisibility": "Public",
+                                    "SlimFaas/NumberParallelJob": "4"},
+                    "ttlSecondsAfterFinished": 3600,
+                    "backoffLimit": 0,
+                    "restartPolicy": "Never",
+                } for name in ("ttl-success", "ttl-failure")
+            },
+        }
+        manifest_path = root / "local.yaml"
+        manifest_path.write_text("\n".join(yaml_mapping(manifest)) + "\n", encoding="utf-8")
+        subprocess.run([*runtime_command, "local", "validate", "-f", str(manifest_path)], check=True)
+
+        def request(path, payload=None):
+            data = None if payload is None else json.dumps(payload).encode()
+            req = urllib.request.Request(f"http://127.0.0.1:{entrypoint}{path}", data=data,
+                                         headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=5) as response:
+                body = response.read()
+                return json.loads(body) if body else None
+
+        log_path = root / "supervisor.log"
+        with log_path.open("w", encoding="utf-8") as log:
+            process = subprocess.Popen(
+                [*runtime_command, "local", "up", "-f", str(manifest_path)],
+                stdout=log, stderr=subprocess.STDOUT, cwd=ROOT,
+                start_new_session=os.name != "nt",
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0)
+            try:
+                deadline = time.monotonic() + 120
+                while True:
+                    if process.poll() is not None:
+                        raise RuntimeError("Local supervisor exited before readiness")
+                    try:
+                        with urllib.request.urlopen(f"http://127.0.0.1:{entrypoint}/ready", timeout=5):
+                            break
+                    except (urllib.error.URLError, ConnectionError, TimeoutError):
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError("Local supervisor never became ready")
+                        time.sleep(.25)
+
+                def wait_for_jobs(name, expected):
+                    deadline = time.monotonic() + 60
+                    while True:
+                        jobs = request(f"/job/{name}")
+                        actual = {job["Id"]: job["Status"] for job in jobs}
+                        if all(actual.get(job_id) == status for job_id, status in expected.items()):
+                            return
+                        if process.poll() is not None or time.monotonic() >= deadline:
+                            raise TimeoutError(f"{name}: expected {expected}, observed {actual}")
+                        time.sleep(.25)
+
+                for name, argument, status in (("ttl-success", "10", "Succeeded"),
+                                               ("ttl-failure", "invalid-number", "Failed")):
+                    expected = {}
+                    for _ in range(4):
+                        # Mutations are issued once; only observation/readiness is polled.
+                        job = request(f"/job/{name}", {"Args": [argument]})
+                        expected[job["Id"]] = status
+                    wait_for_jobs(name, expected)
+                    fifth = request(f"/job/{name}", {"Args": ["10"]})
+                    expected[fifth["Id"]] = "Succeeded"
+                    wait_for_jobs(name, expected)
+                    print(f"PASS {name}: fifth job succeeded; four {status} jobs still retained (TTL 3600s).",
+                          flush=True)
+            except BaseException:
+                log.flush()
+                print(log_path.read_text(encoding="utf-8", errors="replace")[-14000:])
+                raise
+            finally:
+                stop(process)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -222,7 +222,7 @@ You can define multiple jobs definition under the `"Configurations"` key. Each j
 | **Environments**            | Array of environment variables to inject into the job container (e.g., `[{ "name": "MY_ENV", "value": "someValue" }]`).                                                              |
 | **BackoffLimit**            | How many retries are allowed if the job fails before considering it “failed.” (Equivalent to `spec.backoffLimit` in a Kubernetes Job resource.)                                      |
 | **Visibility**              | Either **Public** or **Private**. If **Public**, the job can be triggered from anywhere (outside or inside the cluster). If **Private**, only from trusted pods or internal calls.   |
-| **NumberParallelJob**       | How many pods can run in parallel for this job. If you set `2`, SlimFaas can spin up to 2 concurrent pods for that job.                                                              |
+| **NumberParallelJob**       | Maximum concurrent executions for this job configuration. `Pending` and `Running` executions occupy slots; retained finished jobs do not.                                          |
 | **TtlSecondsAfterFinished** | Time to keep the job resources around after completion (in seconds). For example, `36000` keeps them for 10 hours, after which Kubernetes cleans them up.                            |
 | **RestartPolicy**           | The policy for restarting containers in a pod. Common values: `Never` (don’t restart), `OnFailure` (restart on failure).                                                             |
 
@@ -621,9 +621,33 @@ Set the `Visibility` field inside `Configurations`.
 
 ## 7. Concurrency and Scaling
 
-* `NumberParallelJob` controls simultaneous pods in a single job execution.
+* `NumberParallelJob` limits concurrent executions for each job configuration.
+  `Pending` and `Running` executions reserve slots, including jobs waiting for a
+  retry. `Succeeded` and `Failed` executions release their slots on the next
+  scheduler refresh, even while their resources are retained. The existing
+  `ImagePullBackOff` exemption also applies.
+* `TtlSecondsAfterFinished` controls how long finished resources remain available
+  for inspection. A high TTL does not delay queued work or keep function
+  dependencies awake. Finished jobs keep their terminal status in job listings
+  until cleanup; lowering TTL is not required to free concurrency slots.
+* In Kubernetes, terminal `Complete=True` and `Failed=True` conditions determine
+  completion. Failed pod attempts or partial successes alone do not finish a job
+  that is still executing or retrying.
 * **BackoffLimit** controls total retries.
 * SlimFaas manages creation, dependency checks, and honouring cron schedules without exceeding your limits.
+
+To verify slot reuse with a one-hour TTL using native local mode:
+
+```bash
+dotnet build src/SlimFaas/SlimFaas.csproj
+dotnet build src/FibonacciBatch/FibonacciBatch.csproj
+python3 .bin/test-local-job-concurrency.py
+```
+
+The smoke test uses temporary state and free loopback ports. It completes four
+executions at a parallel limit of four, then verifies a fifth succeeds within
+60 seconds while the first four remain listed. It covers both retained successes
+and retained failures, and stops its local supervisor when finished.
 
 ---
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -641,7 +641,7 @@ To verify slot reuse with a one-hour TTL using native local mode:
 ```bash
 dotnet build src/SlimFaas/SlimFaas.csproj
 dotnet build src/FibonacciBatch/FibonacciBatch.csproj
-python3 .bin/test-local-job-concurrency.py
+python3 tests/SlimFaas.Tests/Local/test_job_concurrency.py
 ```
 
 The smoke test uses temporary state and free loopback ports. It completes four

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -128,6 +128,12 @@ It shows:
 
 If no job configuration is loaded, the section displays an empty state.
 
+The **Running** count includes only executions whose status is `Running`.
+Pending and finished executions remain visible in the details table; `Succeeded`
+and `Failed` entries are retained until their configured TTL expires. Retaining
+finished entries does not occupy parallel job slots or keep their dependencies
+awake. See [job concurrency and retention](jobs.md#7-concurrency-and-scaling).
+
 ---
 
 ## 7. Main Backend Endpoints Used by the UI

--- a/src/SlimFaas/ClientApp/src/App.tsx
+++ b/src/SlimFaas/ClientApp/src/App.tsx
@@ -73,7 +73,8 @@ const App: React.FC = () => {
   const allUp = functions.length > 0 && functions.every((f) => f.NumberReady > 0);
   const totalReady = functions.reduce((sum, f) => sum + (f.NumberReady ?? 0), 0);
   const totalRequested = functions.reduce((sum, f) => sum + (f.NumberRequested ?? 0), 0);
-  const totalRunningJobs = jobs.reduce((sum, j) => sum + (j.RunningJobs ?? []).length, 0);
+  const totalRunningJobs = jobs.reduce((sum, j) =>
+    sum + (j.RunningJobs ?? []).filter((instance) => instance.Status === 'Running').length, 0);
   const totalSchedules = jobs.reduce((sum, j) => sum + (j.Schedules ?? []).length, 0);
 
   return (

--- a/src/SlimFaas/ClientApp/src/components/JobTable.tsx
+++ b/src/SlimFaas/ClientApp/src/components/JobTable.tsx
@@ -51,8 +51,8 @@ const JobTable: React.FC<Props> = ({ jobs }) => {
         </thead>
         <tbody className="job-table__body">
           {jobs.map((job) => {
-            const runningJobs = job.RunningJobs ?? [];
-            const runningCount = runningJobs.length;
+            const retainedJobs = job.RunningJobs ?? [];
+            const runningCount = retainedJobs.filter((instance) => instance.Status === 'Running').length;
             const schedules = job.Schedules ?? [];
 
             return (
@@ -152,8 +152,8 @@ const JobTable: React.FC<Props> = ({ jobs }) => {
                   </td>
                 </tr>
 
-                {/* ── Running jobs always visible ── */}
-                {runningCount > 0 && (
+                {/* Retain finished job details until their configured TTL expires. */}
+                {retainedJobs.length > 0 && (
                   <tr className="job-table__row job-table__row--details">
                     <td className="job-table__td job-table__td--details" colSpan={4}>
                       <table className="job-table__sub-table">
@@ -161,7 +161,7 @@ const JobTable: React.FC<Props> = ({ jobs }) => {
                           <tr><th>Name</th><th>Status</th><th>Element</th><th>Queued</th><th>Started</th></tr>
                         </thead>
                         <tbody>
-                          {runningJobs.map((rj) => (
+                          {retainedJobs.map((rj) => (
                             <tr key={rj.ElementId}>
                               <td>{rj.Name}</td>
                               <td>{rj.Status}</td>

--- a/src/SlimFaas/ClientApp/src/stories/JobTable.stories.tsx
+++ b/src/SlimFaas/ClientApp/src/stories/JobTable.stories.tsx
@@ -90,6 +90,34 @@ export const WithRunningJobs: Story = {
   args: { jobs: JOBS_WITH_RUNNING },
 };
 
+export const RetainedFinishedJobs: Story = {
+  name: 'Finished jobs retained while idle',
+  args: {
+    jobs: [{
+      ...JOBS_IDLE[0],
+      RunningJobs: JOBS_WITH_RUNNING[0].RunningJobs.map((job, index) => ({
+        ...job,
+        Status: index === 0 ? 'Succeeded' : 'Failed',
+      })),
+    }],
+  },
+};
+
+export const MixedJobStates: Story = {
+  name: 'Running, pending and retained finished jobs',
+  args: {
+    jobs: [{
+      ...JOBS_IDLE[0],
+      RunningJobs: ['Running', 'Pending', 'Succeeded', 'Failed'].map((status, index) => ({
+        ...JOBS_WITH_RUNNING[0].RunningJobs[0],
+        Name: `fibonacci-slimfaas-job-${index}`,
+        ElementId: `elem-${index}`,
+        Status: status,
+      })),
+    }],
+  },
+};
+
 export const Empty: Story = {
   name: 'No job configurations',
   args: { jobs: [] },

--- a/src/SlimFaas/Jobs/SlimJobsWorker.cs
+++ b/src/SlimFaas/Jobs/SlimJobsWorker.cs
@@ -51,11 +51,13 @@ public class SlimJobsWorker(
         }
     }
 
-    private async Task DoJobOneCycle(IList<Job> jobs)
+    internal async Task DoJobOneCycle(IList<Job> jobs)
     {
         try
         {
-            jobs = jobs.Where(j => j.Status != JobStatus.ImagePullBackOff).ToList();
+            // Finished jobs remain listed until TTL cleanup, but no longer reserve
+            // execution slots or keep their dependencies awake.
+            jobs = jobs.Where(j => j.Status is JobStatus.Pending or JobStatus.Running).ToList();
             var jobsDictionary = new Dictionary<string, List<Job>>(StringComparer.OrdinalIgnoreCase);
             var configurations = jobConfiguration.Configuration.Configurations;
             foreach (var data in configurations)

--- a/src/SlimFaas/Kubernetes/KubernetesService.Jobs.cs
+++ b/src/SlimFaas/Kubernetes/KubernetesService.Jobs.cs
@@ -172,34 +172,9 @@ public partial class KubernetesService
                 labelSelector: $"slimfaas-job-name={v1Job.Metadata?.Name ?? ""}"
             );
 
-            IList<string> ips = pods.Items.Where(p => p.Status.PodIP != null).Select(p => p.Status.PodIP).ToList();
+            IList<string> ips = pods.Items.Where(p => p.Status?.PodIP != null).Select(p => p.Status.PodIP).ToList();
 
-            JobStatus status = v1Job.Status.Active > 0 ? JobStatus.Running : JobStatus.Pending;
-            if (v1Job.Status.Succeeded is > 0)
-            {
-                status = JobStatus.Succeeded;
-            }
-            else if (v1Job.Status.Failed is > 0)
-            {
-                status = JobStatus.Failed;
-            }
-
-            // Vérifier si un des pods est en PullBackOff ou ErrImagePull
-            foreach (V1Pod? pod in pods.Items)
-            {
-                if (pod.Status.ContainerStatuses == null)
-                {
-                    continue;
-                }
-
-                foreach (V1ContainerStatus? containerStatus in pod.Status.ContainerStatuses)
-                {
-                    if (containerStatus.State.Waiting is { Reason: "ImagePullBackOff" or "ErrImagePull" })
-                    {
-                        status = JobStatus.ImagePullBackOff;
-                    }
-                }
-            }
+            JobStatus status = ResolveJobStatus(v1Job.Status, pods.Items);
 
             List<string> dependsOn = new();
             if (v1Job.Metadata?.Annotations != null && v1Job.Metadata?.Annotations.ContainsKey(DependsOn) == true)
@@ -223,6 +198,38 @@ public partial class KubernetesService
         }
 
         return jobStatus;
+    }
+
+    internal static JobStatus ResolveJobStatus(V1JobStatus? jobStatus, IList<V1Pod> pods)
+    {
+        // Pod counters include previous attempts and partial completions. Only
+        // terminal Job conditions indicate that Kubernetes has finished the Job.
+        if (jobStatus?.Conditions?.Any(condition => condition is { Type: "Complete", Status: "True" }) == true)
+        {
+            return JobStatus.Succeeded;
+        }
+        if (jobStatus?.Conditions?.Any(condition => condition is { Type: "Failed", Status: "True" }) == true)
+        {
+            return JobStatus.Failed;
+        }
+
+        foreach (V1Pod pod in pods)
+        {
+            if (pod.Status?.ContainerStatuses == null)
+            {
+                continue;
+            }
+
+            foreach (V1ContainerStatus? containerStatus in pod.Status.ContainerStatuses)
+            {
+                if (containerStatus?.State?.Waiting is { Reason: "ImagePullBackOff" or "ErrImagePull" })
+                {
+                    return JobStatus.ImagePullBackOff;
+                }
+            }
+        }
+
+        return jobStatus?.Active > 0 ? JobStatus.Running : JobStatus.Pending;
     }
 
     public async Task DeleteJobAsync(string kubeNamespace, string jobName)

--- a/tests/SlimFaas.Tests/Jobs/SlimJobsWorkerConcurrencyTests.cs
+++ b/tests/SlimFaas.Tests/Jobs/SlimJobsWorkerConcurrencyTests.cs
@@ -1,0 +1,170 @@
+using MemoryPack;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SlimData;
+using SlimFaas.Database;
+using SlimFaas.Jobs;
+using SlimFaas.Kubernetes;
+using SlimFaas.Options;
+
+namespace SlimFaas.Tests.Jobs;
+
+public sealed class SlimJobsWorkerConcurrencyTests
+{
+    [Theory]
+    [InlineData(JobStatus.Succeeded)]
+    [InlineData(JobStatus.Failed)]
+    [InlineData(JobStatus.ImagePullBackOff)]
+    public async Task RetainedJobs_DoNotBlockFifthJob(JobStatus retainedStatus)
+    {
+        using var fixture = new Fixture();
+        Job[] retained = Enumerable.Range(0, 4)
+            .Select(index => MakeJob("batch", index.ToString(), retainedStatus))
+            .ToArray();
+
+        await fixture.Worker.DoJobOneCycle(retained);
+
+        fixture.AssertDispatched("batch", 4);
+        Assert.All(retained, job => Assert.Equal(retainedStatus, job.Status));
+    }
+
+    [Fact]
+    public async Task MixedStates_OnlyPendingAndRunningConsumeSlots()
+    {
+        using var fixture = new Fixture();
+
+        await fixture.Worker.DoJobOneCycle([
+            MakeJob("batch", "running", JobStatus.Running),
+            MakeJob("batch", "pending", JobStatus.Pending),
+            MakeJob("batch", "success", JobStatus.Succeeded),
+            MakeJob("batch", "failure", JobStatus.Failed),
+            MakeJob("batch", "pull", JobStatus.ImagePullBackOff)
+        ]);
+
+        fixture.AssertDispatched("batch", 2);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Running)]
+    [InlineData(JobStatus.Pending)]
+    public async Task OccupiedSlots_DoNotDequeue(JobStatus status)
+    {
+        using var fixture = new Fixture();
+
+        await fixture.Worker.DoJobOneCycle(Enumerable.Range(0, 4)
+            .Select(index => MakeJob("batch", index.ToString(), status)).ToArray());
+
+        fixture.Queue.Verify(queue => queue.DequeueAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+        fixture.Service.Verify(service => service.CreateJobAsync(It.IsAny<string>(), It.IsAny<CreateJob>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OccupiedConfiguration_DoesNotBlockAnotherConfiguration()
+    {
+        using var fixture = new Fixture("batch", "other");
+
+        await fixture.Worker.DoJobOneCycle([
+            .. Enumerable.Range(0, 4).Select(index => MakeJob("batch", index.ToString(), JobStatus.Running)),
+            .. Enumerable.Range(0, 4).Select(index => MakeJob("other", index.ToString(), JobStatus.Succeeded))
+        ]);
+
+        fixture.Queue.Verify(queue => queue.DequeueAsync("batch", It.IsAny<int>()), Times.Never);
+        fixture.AssertDispatched("other", 4);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Pending, true)]
+    [InlineData(JobStatus.Running, true)]
+    [InlineData(JobStatus.Succeeded, false)]
+    [InlineData(JobStatus.Failed, false)]
+    [InlineData(JobStatus.ImagePullBackOff, false)]
+    public async Task DependencyActivity_IsOnlyRefreshedForUnfinishedJobs(JobStatus status, bool refresh)
+    {
+        using var fixture = new Fixture();
+        fixture.History.SetTickLastCall("dependency", 1);
+
+        await fixture.Worker.DoJobOneCycle([MakeJob("batch", "existing", status)]);
+
+        long tick = fixture.History.GetTicksLastCall("dependency");
+        Assert.Equal(refresh, tick > 1);
+    }
+
+    [Fact]
+    public async Task Scheduling_DoesNotRemoveFinishedJobsFromListings()
+    {
+        using var fixture = new Fixture();
+        IList<Job> retained = [MakeJob("batch", "success", JobStatus.Succeeded), MakeJob("batch", "failure", JobStatus.Failed)];
+        var kubernetes = new Mock<IKubernetesService>();
+        kubernetes.Setup(service => service.ListJobsAsync(It.IsAny<string>())).ReturnsAsync(retained);
+        var service = new JobService(kubernetes.Object, fixture.Configuration.Object,
+            fixture.Queue.Object, Mock.Of<INamespaceProvider>(), NullLogger<JobService>.Instance);
+
+        await fixture.Worker.DoJobOneCycle(await service.SyncJobsAsync());
+        IList<JobListResult> listed = await service.ListJobAsync("batch");
+
+        Assert.Same(retained, service.Jobs);
+        Assert.Contains(listed, job => job.Id == "success" && job.Status == "Succeeded");
+        Assert.Contains(listed, job => job.Id == "failure" && job.Status == "Failed");
+        kubernetes.Verify(service => service.DeleteJobAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    private static Job MakeJob(string name, string id, JobStatus status) =>
+        new($"{name}{KubernetesService.SlimfaasJobKey}{id}", status, [], ["dependency"], id, 1, 2);
+
+    private sealed class Fixture : IDisposable
+    {
+        public Mock<IJobQueue> Queue { get; } = new(MockBehavior.Strict);
+        public Mock<IJobService> Service { get; } = new(MockBehavior.Strict);
+        public Mock<IJobConfiguration> Configuration { get; } = new(MockBehavior.Strict);
+        public HistoryHttpMemoryService History { get; } = new();
+        public SlimJobsWorker Worker { get; }
+
+        public Fixture(params string[] names)
+        {
+            if (names.Length == 0) names = ["batch"];
+            var configurations = new Dictionary<string, SlimfaasJob>(StringComparer.OrdinalIgnoreCase);
+            foreach (string name in names)
+            {
+                configurations.Add(name, new SlimfaasJob("image", [], NumberParallelJob: 4,
+                    TtlSecondsAfterFinished: 3600));
+                var command = new JobInQueue(new CreateJob([], TtlSecondsAfterFinished: 3600),
+                    $"{name}{KubernetesService.SlimfaasJobKey}fifth", 3);
+                byte[] payload = MemoryPackSerializer.Serialize(command);
+                // Enough waiting work to check the exact available capacity. Only one is returned
+                // by the dequeue mock so creation and acknowledgement can be checked precisely.
+                IList<QueueData> waiting = Enumerable.Range(0, 4).Select(index =>
+                    new QueueData(index.ToString(), payload, 0, true, 1, TimeSpan.TicksPerMinute)).ToArray();
+                Queue.Setup(queue => queue.CountElementAsync(name, It.IsAny<IList<CountType>>(), It.IsAny<int>()))
+                    .ReturnsAsync(waiting);
+                Queue.Setup(queue => queue.DequeueAsync(name, It.IsAny<int>()))
+                    .ReturnsAsync([new QueueData("fifth", payload, 0, false, 1, TimeSpan.TicksPerMinute)]);
+                Queue.Setup(queue => queue.ListCallbackAsync(name, It.IsAny<ListQueueItemStatus>()))
+                    .Returns(Task.CompletedTask);
+                Service.Setup(service => service.CreateJobAsync(name,
+                        It.Is<CreateJob>(job => job.TtlSecondsAfterFinished == 3600), "fifth", command.JobFullName, 3))
+                    .Returns(Task.CompletedTask);
+            }
+            Configuration.SetupGet(configuration => configuration.Configuration)
+                .Returns(new SlimFaasJobConfiguration(configurations));
+            var replicas = new Mock<IReplicasService>();
+            replicas.SetupGet(service => service.Deployments)
+                .Returns(new DeploymentsInformations([], new SlimFaasDeploymentInformation(1, []), []));
+            Worker = new SlimJobsWorker(Queue.Object, Service.Object, Configuration.Object,
+                NullLogger<SlimJobsWorker>.Instance, History, Mock.Of<ISlimDataStatus>(),
+                Mock.Of<IMasterService>(), replicas.Object,
+                Microsoft.Extensions.Options.Options.Create(new WorkersOptions()));
+        }
+
+        public void AssertDispatched(string name, int capacity)
+        {
+            Queue.Verify(queue => queue.DequeueAsync(name, capacity), Times.Once);
+            Service.Verify(service => service.CreateJobAsync(name, It.IsAny<CreateJob>(), "fifth",
+                $"{name}{KubernetesService.SlimfaasJobKey}fifth", 3), Times.Once);
+            Queue.Verify(queue => queue.ListCallbackAsync(name, It.Is<ListQueueItemStatus>(callback =>
+                callback.Items.Count == 1 && callback.Items[0].Id == "fifth" && callback.Items[0].HttpCode == 200)), Times.Once);
+        }
+
+        public void Dispose() => Worker.Dispose();
+    }
+}

--- a/tests/SlimFaas.Tests/Jobs/SlimJobsWorkerConcurrencyTests.cs
+++ b/tests/SlimFaas.Tests/Jobs/SlimJobsWorkerConcurrencyTests.cs
@@ -162,7 +162,7 @@ public sealed class SlimJobsWorkerConcurrencyTests
             Service.Verify(service => service.CreateJobAsync(name, It.IsAny<CreateJob>(), "fifth",
                 $"{name}{KubernetesService.SlimfaasJobKey}fifth", 3), Times.Once);
             Queue.Verify(queue => queue.ListCallbackAsync(name, It.Is<ListQueueItemStatus>(callback =>
-                callback.Items.Count == 1 && callback.Items[0].Id == "fifth" && callback.Items[0].HttpCode == 200)), Times.Once);
+                callback.Items != null && callback.Items.Count == 1 && callback.Items[0].Id == "fifth" && callback.Items[0].HttpCode == 200)), Times.Once);
         }
 
         public void Dispose() => Worker.Dispose();

--- a/tests/SlimFaas.Tests/Kubernetes/KubernetesJobStatusTests.cs
+++ b/tests/SlimFaas.Tests/Kubernetes/KubernetesJobStatusTests.cs
@@ -1,0 +1,91 @@
+using k8s.Models;
+using SlimFaas.Kubernetes;
+
+namespace SlimFaas.Tests.Kubernetes;
+
+public sealed class KubernetesJobStatusTests
+{
+    [Theory]
+    [InlineData("Complete", JobStatus.Succeeded)]
+    [InlineData("Failed", JobStatus.Failed)]
+    public void TerminalCondition_DeterminesFinishedStatus(string condition, JobStatus expected)
+    {
+        var status = new V1JobStatus
+        {
+            Conditions = [new V1JobCondition { Type = condition, Status = "True" }]
+        };
+
+        Assert.Equal(expected, KubernetesService.ResolveJobStatus(status, []));
+    }
+
+    [Theory]
+    [InlineData(1, 0, 1, JobStatus.Running)]
+    [InlineData(0, 0, 1, JobStatus.Pending)]
+    [InlineData(1, 1, 0, JobStatus.Running)]
+    [InlineData(0, 1, 0, JobStatus.Pending)]
+    public void PodCounters_DoNotMakeAnUnfinishedJobTerminal(int active, int succeeded, int failed, JobStatus expected)
+    {
+        var status = new V1JobStatus { Active = active, Succeeded = succeeded, Failed = failed };
+
+        Assert.Equal(expected, KubernetesService.ResolveJobStatus(status, []));
+    }
+
+    [Theory]
+    [InlineData("Complete", "False")]
+    [InlineData("Failed", "Unknown")]
+    [InlineData("FailureTarget", "True")]
+    [InlineData("SuccessCriteriaMet", "True")]
+    public void NonterminalCondition_DoesNotReleaseSlot(string condition, string value)
+    {
+        var status = new V1JobStatus
+        {
+            Active = 1,
+            Conditions = [new V1JobCondition { Type = condition, Status = value }]
+        };
+
+        Assert.Equal(JobStatus.Running, KubernetesService.ResolveJobStatus(status, []));
+    }
+
+    [Theory]
+    [InlineData("Complete", JobStatus.Succeeded)]
+    [InlineData("Failed", JobStatus.Failed)]
+    public void TerminalCondition_TakesPrecedenceOverPodErrors(string condition, JobStatus expected)
+    {
+        var status = new V1JobStatus
+        {
+            Conditions = [new V1JobCondition { Type = condition, Status = "True" }],
+            Succeeded = condition == "Complete" ? 1 : 0,
+            Failed = condition == "Failed" ? 1 : 0
+        };
+
+        Assert.Equal(expected, KubernetesService.ResolveJobStatus(status, [PullErrorPod("ImagePullBackOff")]));
+    }
+
+    [Theory]
+    [InlineData("ImagePullBackOff")]
+    [InlineData("ErrImagePull")]
+    public void UnfinishedJob_PreservesImagePullStatus(string reason)
+    {
+        Assert.Equal(JobStatus.ImagePullBackOff,
+            KubernetesService.ResolveJobStatus(new V1JobStatus(), [PullErrorPod(reason)]));
+    }
+
+    [Fact]
+    public void MissingStatus_IsPending()
+    {
+        Assert.Equal(JobStatus.Pending, KubernetesService.ResolveJobStatus(null, []));
+        Assert.Equal(JobStatus.Pending, KubernetesService.ResolveJobStatus(new V1JobStatus(),
+            [new V1Pod(), new V1Pod { Status = new V1PodStatus() }]));
+    }
+
+    private static V1Pod PullErrorPod(string reason) => new()
+    {
+        Status = new V1PodStatus
+        {
+            ContainerStatuses = [new V1ContainerStatus
+            {
+                State = new V1ContainerState { Waiting = new V1ContainerStateWaiting { Reason = reason } }
+            }]
+        }
+    };
+}

--- a/tests/SlimFaas.Tests/Local/test_job_concurrency.py
+++ b/tests/SlimFaas.Tests/Local/test_job_concurrency.py
@@ -17,7 +17,7 @@ import urllib.error
 import urllib.request
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[3]
 
 
 def yaml_mapping(mapping, indent=0):
@@ -57,6 +57,59 @@ def stop(process):
         else:
             os.killpg(process.pid, signal.SIGKILL)
         process.wait()
+
+
+def request(base_url, path, payload=None):
+    data = None if payload is None else json.dumps(payload).encode()
+    req = urllib.request.Request(base_url + path, data=data,
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5) as response:
+        body = response.read()
+        return json.loads(body) if body else None
+
+
+def wait_for_ready(base_url, process):
+    deadline = time.monotonic() + 120
+    while True:
+        if process.poll() is not None:
+            raise RuntimeError("Local supervisor exited before readiness")
+        try:
+            with urllib.request.urlopen(base_url + "/ready", timeout=5):
+                return
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as error:
+            if isinstance(error, urllib.error.HTTPError):
+                error.close()
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Local supervisor never became ready") from error
+            time.sleep(.25)
+
+
+def wait_for_jobs(base_url, name, expected, process):
+    deadline = time.monotonic() + 60
+    while True:
+        jobs = request(base_url, f"/job/{name}")
+        actual = {job["Id"]: job["Status"] for job in jobs}
+        if all(actual.get(job_id) == status for job_id, status in expected.items()):
+            return
+        if process.poll() is not None or time.monotonic() >= deadline:
+            raise TimeoutError(f"{name}: expected {expected}, observed {actual}")
+        time.sleep(.25)
+
+
+def exercise_slot_reuse(base_url, process):
+    for name, argument, status in (("ttl-success", "10", "Succeeded"),
+                                   ("ttl-failure", "invalid-number", "Failed")):
+        expected = {}
+        for _ in range(4):
+            # Mutations are issued once; only observation/readiness is polled.
+            job = request(base_url, f"/job/{name}", {"Args": [argument]})
+            expected[job["Id"]] = status
+        wait_for_jobs(base_url, name, expected, process)
+        fifth = request(base_url, f"/job/{name}", {"Args": ["10"]})
+        expected[fifth["Id"]] = "Succeeded"
+        wait_for_jobs(base_url, name, expected, process)
+        print(f"PASS {name}: fifth job succeeded; four {status} jobs still retained (TTL 3600s).",
+              flush=True)
 
 
 def main():
@@ -99,14 +152,6 @@ def main():
         manifest_path.write_text("\n".join(yaml_mapping(manifest)) + "\n", encoding="utf-8")
         subprocess.run([*runtime_command, "local", "validate", "-f", str(manifest_path)], check=True)
 
-        def request(path, payload=None):
-            data = None if payload is None else json.dumps(payload).encode()
-            req = urllib.request.Request(f"http://127.0.0.1:{entrypoint}{path}", data=data,
-                                         headers={"Content-Type": "application/json"})
-            with urllib.request.urlopen(req, timeout=5) as response:
-                body = response.read()
-                return json.loads(body) if body else None
-
         log_path = root / "supervisor.log"
         with log_path.open("w", encoding="utf-8") as log:
             process = subprocess.Popen(
@@ -115,42 +160,9 @@ def main():
                 start_new_session=os.name != "nt",
                 creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0)
             try:
-                deadline = time.monotonic() + 120
-                while True:
-                    if process.poll() is not None:
-                        raise RuntimeError("Local supervisor exited before readiness")
-                    try:
-                        with urllib.request.urlopen(f"http://127.0.0.1:{entrypoint}/ready", timeout=5):
-                            break
-                    except (urllib.error.URLError, ConnectionError, TimeoutError):
-                        if time.monotonic() >= deadline:
-                            raise TimeoutError("Local supervisor never became ready")
-                        time.sleep(.25)
-
-                def wait_for_jobs(name, expected):
-                    deadline = time.monotonic() + 60
-                    while True:
-                        jobs = request(f"/job/{name}")
-                        actual = {job["Id"]: job["Status"] for job in jobs}
-                        if all(actual.get(job_id) == status for job_id, status in expected.items()):
-                            return
-                        if process.poll() is not None or time.monotonic() >= deadline:
-                            raise TimeoutError(f"{name}: expected {expected}, observed {actual}")
-                        time.sleep(.25)
-
-                for name, argument, status in (("ttl-success", "10", "Succeeded"),
-                                               ("ttl-failure", "invalid-number", "Failed")):
-                    expected = {}
-                    for _ in range(4):
-                        # Mutations are issued once; only observation/readiness is polled.
-                        job = request(f"/job/{name}", {"Args": [argument]})
-                        expected[job["Id"]] = status
-                    wait_for_jobs(name, expected)
-                    fifth = request(f"/job/{name}", {"Args": ["10"]})
-                    expected[fifth["Id"]] = "Succeeded"
-                    wait_for_jobs(name, expected)
-                    print(f"PASS {name}: fifth job succeeded; four {status} jobs still retained (TTL 3600s).",
-                          flush=True)
+                base_url = f"http://127.0.0.1:{entrypoint}"
+                wait_for_ready(base_url, process)
+                exercise_slot_reuse(base_url, process)
             except BaseException:
                 log.flush()
                 print(log_path.read_text(encoding="utf-8", errors="replace")[-14000:])


### PR DESCRIPTION
Retained finished jobs consumed `NumberParallelJob` slots until TTL cleanup. With a limit of four and four successful jobs retained for one hour, a fifth job remained queued. The scheduler now reserves slots and refreshes dependencies only for pending/running executions, while keeping finished jobs available for inspection.

Kubernetes status mapping now uses terminal `Complete=True` / `Failed=True` conditions, so failed pod attempts and partial completions cannot release slots prematurely. Terminal states take precedence over image-pull errors. Dashboard running counts exclude retained jobs while preserving their details.

Closes #333

## Regression evidence

- Added 28 deterministic tests covering retained successes/failures, mixed states, occupied capacity, independent configurations, dependency activity, retained listings, Kubernetes retries and terminal conditions. Before the fix: **15 failed, 13 passed**. After: **28 passed**, plus all 14 existing targeted tests.
- Added `tests/SlimFaas.Tests/Local/test_job_concurrency.py`, using temporary state, free loopback ports, prebuilt Fibonacci jobs, concurrency four and TTL 3,600 seconds. Before the fix, the fifth job stayed `Queued` for the 60-second deadline despite four `Succeeded` jobs. After the fix, a fifth job succeeds while four successful or failed executions remain retained. The script lives in the test project so analysis classifies it as test code.

## Validation

- Full solution build and `dotnet test --no-build --no-restore --collect "Code Coverage;Format=cobertura"`: **1,177 passed**.
- Native `osx-arm64` AOT publish succeeded, and the TTL smoke test passed with both the managed runtime and the published native executable. Publish reports dependency trim/AOT analysis warnings.
- Standard three-node `slimfaas local` demo: validation passed, four functions listed, and `/function/fibonacci1/hello/local` returned `Hello local!`.
- Node 24 dashboard build and browser checks: mixed/finished/pending/running states, dynamic updates, retained details, mobile layout, keyboard focus, no page errors.
- Documentation lint, eight tests, and static site build passed.

Kubernetes status mapping is unit-tested; live execution checks use native local mode. No dependency, lockfile, public payload, or endpoint changes.
