### PR TITLE
fix: enforce scale-down policy budgets

### DIFF
--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -392,6 +392,25 @@ Conceptually:
 - For **scale-down**:
     - Each policy defines a **maximum allowed decrease**.
     - SlimFaas picks the **most conservative** policy (smallest allowed decrease).
+    - `PeriodSeconds` is a rolling budget, shared by successive decisions. A change
+      stops consuming that budget when its age reaches the configured period.
+      For example, `Pods: 1` over 10 seconds allows `10 → 9`, then holds at 9
+      until that removal expires before allowing `9 → 8`.
+    - The budget counts accepted replica changes, using the count before and after
+      the orchestrator's response and the time it was accepted. Failed writes,
+      unchanged counts, and recommendations blocked by an activity floor or
+      infrastructure protection do not consume capacity-change budget.
+    - For `Percent`, SlimFaas reconstructs the replica count at the start of each
+      policy's window as `current + removed - added`. The quota is
+      `floor(periodStartReplicas × Value / 100)`, minus the replicas already
+      removed in that window. A scale-up does not refund removals. For example,
+      50% of 10 allows five removals in total, even if spread across several decisions.
+      Floor rounding is conservative: 50% of 3 allows one removal, and 50% of 1
+      allows none. Use a suitable policy such as 100% if the last replica must sleep.
+    - Each policy uses its own period. An exhausted policy contributes **zero**
+      to the minimum and blocks further reduction, even if another policy has
+      budget left. `PeriodSeconds: 0` applies the limit independently on each
+      decision, without a rolling budget.
 
 - `StabilizationWindowSeconds`:
     - For scale-down, a non-zero window makes SlimFaas look at the **max desired replicas** in the recent window to avoid flapping.
@@ -399,6 +418,10 @@ Conceptually:
       does not change. The scale-down window therefore starts when demand falls,
       not when the last scale-up happened.
     - For scale-up, you can also use a stabilization window, but the default is usually `0`.
+
+Replica-change history is bounded and held in memory on each SlimFaas node;
+it is not persisted or replicated across leader changes. The dashboard playground
+uses a frozen copy of this same history and does not consume or refresh budgets.
 
 ---
 

--- a/docs/native-local-mode.md
+++ b/docs/native-local-mode.md
@@ -59,6 +59,38 @@ curl http://127.0.0.1:30020/function/fibonacci1/hello/local
 Open <http://127.0.0.1:30020/> to view the live interface. Press `Ctrl+C` in
 the first terminal to stop the demo.
 
+### Understanding the Fibonacci scaling demo
+
+Enqueue work on `fibonacci1` and open **Live Stream → Scaling** at
+<http://127.0.0.1:30020/#/live/scaling> to observe the decisions:
+
+```bash
+curl -i -X POST http://127.0.0.1:30020/async-function/fibonacci1/fibonacci \
+  -H 'Content-Type: application/json' -d '{"input":10}'
+```
+
+Sustained queued work can scale the function up to its configured maximum of
+10 replicas. Three settings explain the subsequent descent:
+
+- The trigger uses `max_over_time(...[30s])`: a queue peak can remain visible
+  for 30 seconds after work drains.
+- `ScaleDown.StabilizationWindowSeconds: 20` holds recent high recommendations
+  for another stabilization window after the recommendation falls.
+- `Pods: 1`, `PeriodSeconds: 10` allows at most one replica removal per rolling
+  10-second window, producing a gradual `10 → 9 → 8 → … → 0` descent.
+
+These windows control different stages; the first reduction also depends on
+metric collection, reconciliation timing, and the observed workload. The HTTP
+inactivity timeout of 10 seconds releases the `ReplicasAtStart` activity floor;
+it does not bypass the scaling policies. The graph shows requested replica
+counts and final targets; process shutdown and readiness can lag those decisions.
+
+Earlier versions could remove two replicas on consecutive decisions because
+the first removal was missing from the period-budget calculation. That is a
+scaler bug, not an intended effect of the 20-second stabilization window.
+See [Policies and stabilization](autoscaling.md#policies-and-stabilization) for
+the budget rules, percentage rounding, and in-memory history limits.
+
 ### Run with an installed SlimFaas executable
 
 From a directory containing the manifest, run:

--- a/src/SlimFaas/Kubernetes/AutoScaler.cs
+++ b/src/SlimFaas/Kubernetes/AutoScaler.cs
@@ -54,9 +54,10 @@ public sealed class AutoScaler
         return ComputeDecision(deployment, nowUnixSeconds, evaluation, recordDecision).Target;
     }
 
-    internal void RecordAppliedDecision(string function, long nowUnixSeconds, int replicas)
+    internal void RecordAppliedDecision(string function, long nowUnixSeconds, int previousReplicas, int replicas)
     {
-        lock (_historyLock) _store.AddSample(function, nowUnixSeconds, replicas);
+        if (replicas == previousReplicas) return;
+        lock (_historyLock) _store.AddSample(function, nowUnixSeconds, replicas, previousReplicas);
     }
 
     public int ComputeDesiredReplicas(DeploymentInformation deployment, long nowUnixSeconds)
@@ -104,7 +105,7 @@ public sealed class AutoScaler
             var result = MetricsScalingCalculator.Calculate(config, current, min, max, now, evaluation, CaptureHistory(key));
             if (config is null || config.Triggers.Count == 0) return result;
             _recommendationStore.AddSample(key, now, result.Recommendation);
-            if (recordDecision && result.Target != Math.Max(0, current)) _store.AddSample(key, now, result.Target);
+            if (recordDecision) RecordAppliedDecision(key, now, Math.Max(0, current), result.Target);
             foreach (var trigger in result.Triggers)
             {
                 var configuredTrigger = config.Triggers[trigger.Index];

--- a/src/SlimFaas/Kubernetes/AutoScalerStabilisation.cs
+++ b/src/SlimFaas/Kubernetes/AutoScalerStabilisation.cs
@@ -9,6 +9,9 @@ public interface IAutoScalerStore
     /// </summary>
     void AddSample(string key, long timestampUnixSeconds, int desiredReplicas);
 
+    /// <summary>Records a replica change, including the count before the change.</summary>
+    void AddSample(string key, long timestampUnixSeconds, int desiredReplicas, int previousReplicas);
+
     /// <summary>
     /// Récupère tous les échantillons >= fromTimestampUnixSeconds pour un déploiement.
     /// </summary>
@@ -19,11 +22,13 @@ public readonly struct AutoScaleSample
 {
     public long TimestampUnixSeconds { get; }
     public int DesiredReplicas { get; }
+    public int? PreviousReplicas { get; }
 
-    public AutoScaleSample(long timestampUnixSeconds, int desiredReplicas)
+    public AutoScaleSample(long timestampUnixSeconds, int desiredReplicas, int? previousReplicas = null)
     {
         TimestampUnixSeconds = timestampUnixSeconds;
         DesiredReplicas = desiredReplicas;
+        PreviousReplicas = previousReplicas;
     }
 }
 
@@ -39,11 +44,17 @@ public sealed class InMemoryAutoScalerStore : IAutoScalerStore
     }
 
     public void AddSample(string key, long timestampUnixSeconds, int desiredReplicas)
+        => AddSample(key, new AutoScaleSample(timestampUnixSeconds, desiredReplicas));
+
+    public void AddSample(string key, long timestampUnixSeconds, int desiredReplicas, int previousReplicas)
+        => AddSample(key, new AutoScaleSample(timestampUnixSeconds, desiredReplicas, previousReplicas));
+
+    private void AddSample(string key, AutoScaleSample sample)
     {
         var list = _samples.GetOrAdd(key, _ => new List<AutoScaleSample>());
         lock (list)
         {
-            list.Add(new AutoScaleSample(timestampUnixSeconds, desiredReplicas));
+            list.Add(sample);
             var overflow = list.Count - _maxSamplesPerKey;
             if (overflow > 0)
             {

--- a/src/SlimFaas/ReplicasService.cs
+++ b/src/SlimFaas/ReplicasService.cs
@@ -96,7 +96,6 @@ public class ReplicasService(
         diagnostics?.Retain(currentDeployments.Functions.Select(f => f.Deployment).ToHashSet(StringComparer.Ordinal));
 
         List<Task<ReplicaRequest?>> tasks = new();
-        var deferredDecisions = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (DeploymentInformation deploymentInformation in currentDeployments.Functions)
         {
@@ -108,10 +107,9 @@ public class ReplicasService(
                         + TimeSpan.FromSeconds(context.TimeoutSeconds) - TimeSpan.FromTicks(nowUtc.Ticks));
             int currentScale = deploymentInformation.Replicas;
             evaluations.TryGetValue(deploymentInformation.Deployment, out var evaluation);
-            bool deferDecision = deploymentInformation.Scale?.Triggers.Any(t => t.Source is not null) == true;
             MetricsScalingDecision? metrics = null;
             if (ScalingDecisionCalculator.NeedsMetrics(context, evaluation))
-                metrics = autoScaler.ComputeDecision(deploymentInformation, nowUnixSeconds, evaluation!, !deferDecision);
+                metrics = autoScaler.ComputeDecision(deploymentInformation, nowUnixSeconds, evaluation!, recordDecision: false);
             var decision = ScalingDecisionCalculator.Calculate(context, evaluation, metrics,
                 SourceDiagnostics(deploymentInformation, nowUnixSeconds));
             if (decision.Reasons.Any(r => r.Code == "InfrastructureBlocked"))
@@ -131,7 +129,6 @@ public class ReplicasService(
             logger.LogInformation("Scale {Deployment} from {CurrentScale} to {DesiredReplicas}",
                 deploymentInformation.Deployment, currentScale, desiredReplicas);
 
-            if (deferDecision) deferredDecisions.Add(deploymentInformation.Deployment);
             tasks.Add(ApplyScaleAsync(decision, deploymentInformation.Scale, diagnosticSession, new ReplicaRequest(
                 Replicas: desiredReplicas,
                 Deployment: deploymentInformation.Deployment,
@@ -142,28 +139,21 @@ public class ReplicasService(
 
         if (tasks.Count > 0)
         {
-            List<DeploymentInformation> updatedFunctions = new();
-            ReplicaRequest?[] replicaRequests = await Task.WhenAll(tasks);
-            var requestsByDeployment = replicaRequests
-                .Where(r => r is not null)
-                .ToDictionary(r => r!.Deployment, r => r!, StringComparer.Ordinal);
-
-            foreach (DeploymentInformation function in currentDeployments.Functions)
+            try
             {
-                if (requestsByDeployment.TryGetValue(function.Deployment, out var updatedRequest))
-                {
-                    updatedFunctions.Add(function with { Replicas = updatedRequest.Replicas });
-                    if (deferredDecisions.Contains(function.Deployment))
-                        autoScaler.RecordAppliedDecision(function.Deployment, nowUnixSeconds, updatedRequest.Replicas);
-                }
-                else
-                {
-                    updatedFunctions.Add(function);
-                }
+                await Task.WhenAll(tasks);
             }
-
-            var updatedDeployments = currentDeployments with { Functions = updatedFunctions };
-            Interlocked.Exchange(ref _deployments, updatedDeployments);
+            finally
+            {
+                // Preserve successful writes even if another function's write failed.
+                var requestsByDeployment = tasks.Where(t => t.IsCompletedSuccessfully)
+                    .Select(t => t.Result).Where(r => r is not null)
+                    .ToDictionary(r => r!.Deployment, r => r!, StringComparer.Ordinal);
+                var updatedFunctions = currentDeployments.Functions.Select(function =>
+                    requestsByDeployment.TryGetValue(function.Deployment, out var request)
+                        ? function with { Replicas = request.Replicas } : function).ToList();
+                Interlocked.Exchange(ref _deployments, currentDeployments with { Functions = updatedFunctions });
+            }
         }
     }
 
@@ -173,6 +163,9 @@ public class ReplicasService(
         {
             diagnostics?.Record(decision with { Application = "Sent" }, configuration, session);
             var result = await kubernetesService.ScaleAsync(request);
+            if (result is not null && configuration?.Triggers.Count > 0)
+                autoScaler.RecordAppliedDecision(decision.Function, new DateTimeOffset(_nowProvider()).ToUnixTimeSeconds(),
+                    decision.CurrentReplicas, result.Replicas);
             diagnostics?.Record(decision with { Application = result is null ? "Failed" : "Accepted",
                 AcceptedReplicas = result?.Replicas }, configuration, session);
             return result;

--- a/src/SlimFaas/Scaling/MetricsScalingCalculator.cs
+++ b/src/SlimFaas/Scaling/MetricsScalingCalculator.cs
@@ -177,39 +177,32 @@ internal static class MetricsScalingCalculator
             if (policy.Value <= 0)
                 continue;
 
-            var baseDelta = ComputeDelta(policy, currentReplicas);
-            if (baseDelta <= 0)
-                continue;
-
+            long removed = 0, added = 0;
             if (policy.PeriodSeconds > 0)
             {
                 var fromTs = nowUnixSeconds - policy.PeriodSeconds;
-                var samples = decisions.Where(s => s.TimestampUnixSeconds >= fromTs).ToArray();
-
-                // baseline = max(desired) dans la fenêtre => point le plus haut
-                var baseline = currentReplicas;
-                if (samples.Length > 0)
+                foreach (var sample in decisions)
                 {
-                    baseline = samples[0].DesiredReplicas;
-                    for (var i = 1; i < samples.Length; i++)
-                    {
-                        if (samples[i].DesiredReplicas > baseline)
-                            baseline = samples[i].DesiredReplicas;
-                    }
+                    // A change expires exactly at PeriodSeconds. Recommendations have no previous count.
+                    if (sample.TimestampUnixSeconds <= fromTs || sample.TimestampUnixSeconds > nowUnixSeconds ||
+                        sample.PreviousReplicas is not { } previous) continue;
+                    long delta = (long)sample.DesiredReplicas - previous;
+                    if (delta < 0) removed -= delta;
+                    else added += delta;
                 }
-
-                var alreadyDown = Math.Max(0, baseline - currentReplicas);
-                var remainingDown = Math.Max(0, policy.Value - alreadyDown);
-                if (remainingDown <= 0)
-                    continue;
-
-                baseDelta = Math.Min(baseDelta, remainingDown);
-                if (baseDelta <= 0)
-                    continue;
             }
 
-            if (minAllowedDelta is null || baseDelta < minAllowedDelta.Value)
-                minAllowedDelta = baseDelta;
+            long periodStart = Math.Clamp(currentReplicas + removed - added, 0, int.MaxValue);
+            long quota = policy.Type switch
+            {
+                ScalePolicyType.Pods => policy.Value,
+                // Integer arithmetic preserves floor rounding without overflow or floating-point error.
+                ScalePolicyType.Percent => periodStart * policy.Value / 100,
+                _ => 0
+            };
+            // Adding replicas does not refund removals. Zero must participate in the conservative minimum.
+            int remaining = (int)Math.Clamp(quota - removed, 0, currentReplicas);
+            minAllowedDelta = Math.Min(minAllowedDelta ?? remaining, remaining);
         }
 
         if (minAllowedDelta is null)

--- a/tests/SlimFaas.Tests/Kubernetes/AutoScalerNoTrafficTests.cs
+++ b/tests/SlimFaas.Tests/Kubernetes/AutoScalerNoTrafficTests.cs
@@ -70,7 +70,7 @@ namespace SlimFaas.Tests.Kubernetes
         }
 
         [Fact]
-        public void ComputeDesiredReplicas_NoTraffic_ShouldStoreRawDesiredZero_AndScaleDownByOne()
+        public void ComputeDesiredReplicas_NoTraffic_ShouldStoreReplicaChange_AndScaleDownByOne()
         {
             // Arrange
             var evaluator = CreateEvaluatorWithDummySnapshot();
@@ -103,10 +103,9 @@ namespace SlimFaas.Tests.Kubernetes
             // Assert : on scale down d'un seul pod (9 -> 8)
             Assert.Equal(8, desired);
 
-            // Et on vérifie que ce qui est stocké dans le store est bien le rawDesired = 0,
-            // pas la valeur finale 8.
+            // The policy history records the change; raw recommendations are kept separately.
             storeMock.Verify(
-                s => s.AddSample("ns/app", now, 8),
+                s => s.AddSample("ns/app", now, 8, 9),
                 Times.Once);
         }
 
@@ -155,9 +154,9 @@ namespace SlimFaas.Tests.Kubernetes
             Assert.Equal(1, desired2);
             Assert.Equal(0, desired3);
 
-            // Et on vérifie accessoirement qu'on a bien stocké 3 rawDesired = 0
+            // The final change reaches zero from one replica.
             storeMock.Verify(
-                s => s.AddSample("ns/app", It.IsAny<long>(), 0),
+                s => s.AddSample("ns/app", It.IsAny<long>(), 0, 1),
                 Times.Exactly(1));
         }
     }

--- a/tests/SlimFaas.Tests/Kubernetes/AutoScalerPeriodPoliciesMoreTests.cs
+++ b/tests/SlimFaas.Tests/Kubernetes/AutoScalerPeriodPoliciesMoreTests.cs
@@ -78,10 +78,10 @@ namespace SlimFaas.Tests.Kubernetes
             var storeMock = new Mock<IAutoScalerStore>();
 
             storeMock
-                .Setup(s => s.AddSample(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<int>()))
-                .Callback<string, long, int>((key, ts, desired) =>
+                .Setup(s => s.AddSample(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Callback<string, long, int, int>((key, ts, desired, previous) =>
                 {
-                    samples.Add(new AutoScaleSample(ts, desired));
+                    samples.Add(new AutoScaleSample(ts, desired, previous));
                 });
 
             storeMock
@@ -143,10 +143,10 @@ namespace SlimFaas.Tests.Kubernetes
             var storeMock = new Mock<IAutoScalerStore>();
 
             storeMock
-                .Setup(s => s.AddSample(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<int>()))
-                .Callback<string, long, int>((key, ts, desired) =>
+                .Setup(s => s.AddSample(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Callback<string, long, int, int>((key, ts, desired, previous) =>
                 {
-                    samples.Add(new AutoScaleSample(ts, desired));
+                    samples.Add(new AutoScaleSample(ts, desired, previous));
                 });
 
             storeMock

--- a/tests/SlimFaas.Tests/Kubernetes/AutoScalerPeriodPoliciesTests.cs
+++ b/tests/SlimFaas.Tests/Kubernetes/AutoScalerPeriodPoliciesTests.cs
@@ -145,9 +145,8 @@ namespace SlimFaas.Tests.Kubernetes
         {
             // current = 8, raw desired = 1
             // Policy: Pods, Value = 2, Period = 30s
-            // Historique: dans la fenêtre, desired = 10 puis 9
-            // baseline = max(10,9) = 10
-            // alreadyDown = baseline(10) - current(8) = 2
+            // Historique: dans la fenêtre, 10 -> 9 puis 9 -> 8
+            // alreadyDown = 1 + 1 = 2
             // remainingDown = 2 - 2 = 0 => aucun scale-down autorisé
             // => on ne bouge pas : final = current = 8
 
@@ -170,8 +169,8 @@ namespace SlimFaas.Tests.Kubernetes
 
             var samples = new List<AutoScaleSample>
             {
-                new AutoScaleSample(timestampUnixSeconds: 1975, desiredReplicas: 10),
-                new AutoScaleSample(timestampUnixSeconds: 1985, desiredReplicas: 9),
+                new AutoScaleSample(timestampUnixSeconds: 1975, desiredReplicas: 9, previousReplicas: 10),
+                new AutoScaleSample(timestampUnixSeconds: 1985, desiredReplicas: 8, previousReplicas: 9),
             };
 
             var storeMock = new Mock<IAutoScalerStore>();

--- a/tests/SlimFaas.Tests/Scaling/ScaleDownBudgetTests.cs
+++ b/tests/SlimFaas.Tests/Scaling/ScaleDownBudgetTests.cs
@@ -1,0 +1,289 @@
+using Moq;
+using SlimFaas.Kubernetes;
+using SlimFaas.Scaling;
+using Xunit;
+
+namespace SlimFaas.Tests.Scaling;
+
+public class ScaleDownBudgetTests
+{
+    private static async Task<ScalingTestFixture> Create(int replicas = 10, ScalePolicy[]? policies = null,
+        bool local = false, int stabilization = 0)
+    {
+        var fixture = new ScalingTestFixture();
+        fixture.Config = fixture.Config with
+        {
+            Behavior = new ScaleBehavior
+            {
+                ScaleUp = new() { Policies = [] },
+                ScaleDown = new()
+                {
+                    Policies = policies ?? [new(ScalePolicyType.Pods, 1, 10)],
+                    StabilizationWindowSeconds = stabilization
+                }
+            }
+        };
+        if (local) fixture.Config.Triggers[0] = fixture.Config.Triggers[0] with { Source = null };
+        await fixture.SetFunctions(replicas);
+        return fixture;
+    }
+
+    private static async Task<int> Tick(ScalingTestFixture fixture, int elapsedSeconds, double pending = 0)
+    {
+        fixture.Time.Now = DateTimeOffset.FromUnixTimeSeconds(1000 + elapsedSeconds);
+        fixture.Scrape(pending);
+        if (fixture.Config.Triggers[0].Source is null)
+            fixture.Metrics.Add(fixture.Time.Now.ToUnixTimeSeconds(), fixture.Name, "pod",
+                new Dictionary<string, double> { ["jobs_pending"] = pending });
+        await fixture.Replicas.CheckScaleAsync("default");
+        return fixture.Replicas.Deployments.Functions[0].Replicas;
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TenReplicasDecreaseOnePerPeriodUntilZero(bool local)
+    {
+        var fixture = await Create(local: local);
+        for (int elapsed = 0; elapsed <= 100; elapsed++)
+        {
+            int expected = Math.Max(0, 9 - elapsed / 10);
+            Assert.Equal(expected, await Tick(fixture, elapsed));
+        }
+        Assert.Equal(10, fixture.Scaler.CaptureHistory(fixture.Name).Decisions.Count);
+    }
+
+    [Fact]
+    public async Task SameSecondAndUnexpiredPeriodCannotRemoveAnotherReplica()
+    {
+        var fixture = await Create();
+        Assert.Equal(9, await Tick(fixture, 0));
+        Assert.Equal(9, await Tick(fixture, 0));
+        Assert.Equal(9, await Tick(fixture, 9));
+        Assert.Equal(8, await Tick(fixture, 10));
+        Assert.Equal(8, await Tick(fixture, 11));
+    }
+
+    [Fact]
+    public async Task PartialRemovalsShareTheirBudgetEvenInTheSameSecond()
+    {
+        var fixture = await Create(policies: [new(ScalePolicyType.Pods, 3, 10)]);
+        Assert.Equal(9, await Tick(fixture, 0, 90));
+        Assert.Equal(7, await Tick(fixture, 0));
+        Assert.Equal(7, await Tick(fixture, 9));
+        Assert.Equal(4, await Tick(fixture, 10));
+    }
+
+    [Theory]
+    [InlineData(3, 50, 2)]
+    [InlineData(1, 50, 1)]
+    [InlineData(100, 29, 71)]
+    [InlineData(200, 10, 180)]
+    [InlineData(3, 100, 0)]
+    public async Task PercentUsesAReplicaQuotaWithFloorRounding(int current, int percent, int expected)
+    {
+        var fixture = await Create(current, [new(ScalePolicyType.Percent, percent, 10)]);
+        fixture.Config = fixture.Config with { ReplicaMax = current };
+        await fixture.SetFunctions(current);
+        Assert.Equal(expected, await Tick(fixture, 0));
+        Assert.Equal(expected, await Tick(fixture, 1));
+    }
+
+    [Fact]
+    public async Task PercentBudgetUsesPeriodStartInsteadOfShrinkingAfterEachPartialRemoval()
+    {
+        var fixture = await Create(policies: [new(ScalePolicyType.Percent, 50, 10)]);
+        Assert.Equal(8, await Tick(fixture, 0, 80));
+        Assert.Equal(5, await Tick(fixture, 1));
+        Assert.Equal(5, await Tick(fixture, 9));
+        // The first removal expired: the period starts at eight, with three removals still counted.
+        Assert.Equal(4, await Tick(fixture, 10));
+        Assert.Equal(3, await Tick(fixture, 11));
+    }
+
+    [Theory]
+    [InlineData(ScalePolicyType.Pods, 2)]
+    [InlineData(ScalePolicyType.Percent, 20)]
+    public async Task ScaleUpDoesNotRefundRemovals(ScalePolicyType type, int value)
+    {
+        var fixture = await Create(policies: [new(type, value, 10)]);
+        Assert.Equal(8, await Tick(fixture, 0));
+        Assert.Equal(10, await Tick(fixture, 1, 100));
+        Assert.Equal(10, await Tick(fixture, 2));
+        Assert.Equal(type == ScalePolicyType.Pods ? 8 : 9, await Tick(fixture, 10));
+    }
+
+    [Fact]
+    public async Task ExhaustedPolicyStillLimitsOtherPoliciesWithDifferentPeriods()
+    {
+        var fixture = await Create(policies: [new(ScalePolicyType.Pods, 1, 10), new(ScalePolicyType.Pods, 2, 30)]);
+        Assert.Equal(9, await Tick(fixture, 0));
+        Assert.Equal(9, await Tick(fixture, 1));
+        Assert.Equal(8, await Tick(fixture, 10));
+        Assert.Equal(8, await Tick(fixture, 20));
+        Assert.Equal(7, await Tick(fixture, 30));
+        Assert.Equal(6, await Tick(fixture, 40));
+    }
+
+    [Fact]
+    public async Task RoundedZeroPercentageParticipatesInConservativeMinimum()
+    {
+        var fixture = await Create(1, [new(ScalePolicyType.Percent, 50, 0), new(ScalePolicyType.Pods, 1, 10)]);
+        Assert.Equal(1, await Tick(fixture, 0));
+        Assert.Empty(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+    }
+
+    [Fact]
+    public async Task ZeroPeriodLimitsEachDecisionWithoutATemporalBudget()
+    {
+        var fixture = await Create(3, [new(ScalePolicyType.Pods, 1, 0)]);
+        Assert.Equal(2, await Tick(fixture, 0));
+        Assert.Equal(1, await Tick(fixture, 0));
+        Assert.Equal(0, await Tick(fixture, 0));
+    }
+
+    [Fact]
+    public async Task LongHighDemandPlateauRefreshesStabilizationBeforeGradualReduction()
+    {
+        var fixture = await Create(stabilization: 20);
+        for (int elapsed = 0; elapsed <= 120; elapsed++)
+            Assert.Equal(10, await Tick(fixture, elapsed, 100));
+        for (int elapsed = 121; elapsed <= 140; elapsed++)
+            Assert.Equal(10, await Tick(fixture, elapsed));
+        Assert.Empty(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+        Assert.Equal(9, await Tick(fixture, 141));
+        Assert.Equal(9, await Tick(fixture, 150));
+        Assert.Equal(8, await Tick(fixture, 151));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ActivityFloorOnlyConsumesAcceptedReduction(bool local)
+    {
+        var fixture = await Create(policies: [new(ScalePolicyType.Pods, 3, 10)], local: local);
+        var function = fixture.Replicas.Deployments.Functions[0] with { ReplicasAtStart = 9 };
+        await fixture.SetFunctions(functions: [function]);
+        fixture.Http.SetTickLastCall(fixture.Name, fixture.Time.Now.UtcDateTime.Ticks);
+        Assert.Equal(9, await Tick(fixture, 0));
+        Assert.Equal(9, await Tick(fixture, 1));
+        var change = Assert.Single(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+        Assert.Equal(10, change.PreviousReplicas);
+        Assert.Equal(9, change.DesiredReplicas);
+        fixture.Http.SetTickLastCall(fixture.Name, 0);
+        Assert.Equal(7, await Tick(fixture, 2));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task FailedWriteLeavesBudgetAvailable(bool local, bool throws)
+    {
+        var fixture = await Create(local: local);
+        if (throws)
+            fixture.Kubernetes.Setup(k => k.ScaleAsync(It.IsAny<ReplicaRequest>())).ThrowsAsync(new InvalidOperationException());
+        else
+            fixture.Kubernetes.Setup(k => k.ScaleAsync(It.IsAny<ReplicaRequest>())).ReturnsAsync((ReplicaRequest?)null);
+        if (throws) await Assert.ThrowsAsync<InvalidOperationException>(() => Tick(fixture, 0));
+        else Assert.Equal(10, await Tick(fixture, 0));
+        Assert.Empty(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+        fixture.Kubernetes.Setup(k => k.ScaleAsync(It.IsAny<ReplicaRequest>())).ReturnsAsync((ReplicaRequest r) => r);
+        Assert.Equal(9, await Tick(fixture, 1));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AcceptedCountAndAcceptanceTimeDetermineBudget(bool local)
+    {
+        var fixture = await Create(policies: [new(ScalePolicyType.Pods, 3, 10)], local: local);
+        fixture.Kubernetes.Setup(k => k.ScaleAsync(It.IsAny<ReplicaRequest>())).ReturnsAsync((ReplicaRequest r) =>
+        {
+            fixture.Time.Now = fixture.Time.Now.AddSeconds(5);
+            return r with { Replicas = 9 };
+        });
+        Assert.Equal(9, await Tick(fixture, 0));
+        var change = Assert.Single(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+        Assert.Equal(1005, change.TimestampUnixSeconds);
+        Assert.Equal(10, change.PreviousReplicas);
+        Assert.Equal(9, change.DesiredReplicas);
+        fixture.Kubernetes.Setup(k => k.ScaleAsync(It.IsAny<ReplicaRequest>())).ReturnsAsync((ReplicaRequest r) => r);
+        Assert.Equal(7, await Tick(fixture, 6));
+        Assert.Equal(7, await Tick(fixture, 14));
+        Assert.Equal(6, await Tick(fixture, 15));
+    }
+
+    [Fact]
+    public async Task UnchangedAcceptedCountConsumesNoBudget()
+    {
+        var fixture = await Create();
+        fixture.Kubernetes.Setup(k => k.ScaleAsync(It.IsAny<ReplicaRequest>())).ReturnsAsync((ReplicaRequest r) => r with { Replicas = 10 });
+        Assert.Equal(10, await Tick(fixture, 0));
+        Assert.Empty(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+        fixture.Kubernetes.Setup(k => k.ScaleAsync(It.IsAny<ReplicaRequest>())).ReturnsAsync((ReplicaRequest r) => r);
+        Assert.Equal(9, await Tick(fixture, 1));
+    }
+
+    [Fact]
+    public async Task AnotherFunctionsFailurePreservesSuccessfulChangeAndReplicaCount()
+    {
+        var fixture = await Create();
+        var other = fixture.Replicas.Deployments.Functions[0] with { Deployment = fixture.Name + "-failed" };
+        await fixture.SetFunctions(functions: [fixture.Replicas.Deployments.Functions[0], other]);
+        fixture.Scrape(0, other.Deployment);
+        fixture.Kubernetes.Setup(k => k.ScaleAsync(It.Is<ReplicaRequest>(r => r.Deployment == other.Deployment)))
+            .ThrowsAsync(new InvalidOperationException());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Tick(fixture, 0));
+        Assert.Equal(9, fixture.Replicas.Deployments.Functions[0].Replicas);
+        Assert.Equal(10, fixture.Replicas.Deployments.Functions[1].Replicas);
+        Assert.Single(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+        Assert.Empty(fixture.Scaler.CaptureHistory(other.Deployment).Decisions);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BlockedScaleUpConsumesNoBudget(bool local)
+    {
+        var fixture = await Create(local: local);
+        var function = fixture.Replicas.Deployments.Functions[0] with
+        {
+            Pods = [new("blocked", false, false, "127.0.0.1", fixture.Name) { StartFailureReason = "Unschedulable" }]
+        };
+        await fixture.SetFunctions(functions: [function]);
+        Assert.Equal(10, await Tick(fixture, 0, 200));
+        Assert.Empty(fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+    }
+
+    [Fact]
+    public async Task InvalidTriggerPreventsReductionEvenAfterBudgetExpires()
+    {
+        var fixture = await Create();
+        Assert.Equal(9, await Tick(fixture, 0));
+        fixture.Config.Triggers.Add(new(Query: "missing_metric", Threshold: 1));
+        Assert.Equal(9, await Tick(fixture, 10));
+        fixture.Config.Triggers.RemoveAt(1);
+        Assert.Equal(8, await Tick(fixture, 10));
+    }
+
+    [Fact]
+    public async Task PreviewUsesAcceptedChangesWithoutConsumingOrRefreshingHistory()
+    {
+        var fixture = await Create();
+        Assert.Equal(9, await Tick(fixture, 0));
+        foreach (int elapsed in new[] { 1, 10 })
+        {
+            fixture.Time.Now = DateTimeOffset.FromUnixTimeSeconds(1000 + elapsed);
+            fixture.Scrape(0);
+            var before = fixture.Scaler.CaptureHistory(fixture.Name);
+            var preview = await fixture.Simulation.SimulateAsync(new(fixture.Name), default);
+            Assert.Equal(elapsed == 1 ? 9 : 8, preview.Current.Target);
+            Assert.Equal(preview.Current.Target, preview.Simulated.Target);
+            Assert.Equal(before.Decisions, fixture.Scaler.CaptureHistory(fixture.Name).Decisions);
+            Assert.Equal(before.Recommendations, fixture.Scaler.CaptureHistory(fixture.Name).Recommendations);
+            Assert.Equal(preview.Current.Target, await Tick(fixture, elapsed));
+        }
+    }
+}


### PR DESCRIPTION
When the demo queue drained, a `Pods: 1, PeriodSeconds: 10` scale-down policy could remove replicas on consecutive decisions (`10 → 9 → 8`). The policy history stored only resulting targets, so the first removal disappeared from the budget calculation. This change records before/after replica counts and enforces a shared rolling budget across decisions.

- Record accepted changes and their acceptance time for local and external triggers, using the orchestrator's accepted count. Failed, blocked and unchanged decisions consume no budget; successful writes survive another function's failure.
- Calculate percentage quotas from the period-start replica count with the existing floor rounding, subtract actual removals, and include exhausted policies in the conservative minimum. Each policy uses its own period; scale-up does not refund removals.
- Keep runtime and dashboard simulation on the same captured history and document the demo's separate 30-second metric window, 20-second stabilization window and 10-second removal budget.

Validation:
- Two regression tests reproduced the bug on the starting `main` before the fix (expected 9, actual 8).
- `dotnet test`: 1,419 passed, including 30 new regression cases covering local/external triggers, period boundaries, percentage and combined policies, stabilization, activity floors, failures and simulation isolation.
- `dotnet publish src/SlimFaas/SlimFaas.csproj -c Release -r osx-arm64`: succeeded; the native executable also validated the demo manifest.
- Documentation site: `pnpm install --frozen-lockfile && pnpm build` passed, including the exported-page/link checks, using Node 24.
- Stock three-node native-local demo (only the state directory isolated): 3,165 Fibonacci requests accepted, 10 ready replicas reached, then ten accepted reductions from 10 to 0, spaced 10.010–10.025 seconds apart. Status and `/function/fibonacci1/hello/local` smoke checks passed. The recorded SSE history was filtered from the ten-ready-replica peak to exclude the earlier smoke request's idle shutdown.

Fixes #347
