### PR TITLE
fix: recover job dispatch after stalled SlimData operations

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -27,6 +27,32 @@ flowchart TD
 
 In the dashboard, **Jobs Overview** shows configurations and running work. List executions with `GET /job/name` and create/delete your own schedules in the [job exercise](guided-tour.md#6-run-jobs-and-manage-schedules). CPU/memory resource limits depend on the orchestrator; native local processes do not enforce container limits.
 
+### Recovery after a temporary SlimData interruption
+
+An HTTP `202 Accepted` response means the job has been queued; execution still waits
+for dependencies, an available concurrency slot and the cluster leader. A temporary
+SlimData interruption can delay dispatch. Once the cluster can make progress again,
+SlimFaas retries queue operations without requiring a node restart.
+
+Queue reads wait at most five seconds per attempt for the committed Raft log to be
+applied locally. An expiration is reported as a SlimData unavailability error and
+retried; if those retries are exhausted, the jobs worker can try again on a later
+cycle. Internal mutation requests keep their HTTP timeout active until the complete
+response body arrives, including when the response headers have already arrived.
+The default internal HTTP timeout is 100 seconds.
+
+If a mutation response is lost or times out, SlimFaas retries the same ordered batch
+against the current leader. Its producer, generation, sequence and request IDs are
+preserved so SlimData can return the previously committed result without applying
+the queue mutation twice. These transport retries are separate from retries of the
+job program itself. This does not provide an exactly-once guarantee for external
+side effects performed by a job.
+
+If jobs remain queued after recovery, check dependency readiness, active jobs and
+the node logs for `Raft local log application timed out` or
+`Retrying the same ordered SlimData batch`. Retained `Succeeded` and `Failed` jobs
+do not occupy concurrency slots.
+
 ## 1. Why Use Jobs?
 
 * **Short‑lived or periodic tasks** — perform a specialised computation once or on a fixed cadence and then shut down.

--- a/src/SlimFaas/Database/SlimDataService.cs
+++ b/src/SlimFaas/Database/SlimDataService.cs
@@ -434,9 +434,12 @@ public sealed class SlimDataService : IDatabaseService, IAsyncDisposable
             Content = new ByteArrayContent(payload)
         };
         HttpClient httpClient = _batchHttpClient ??= _httpClientFactory.CreateClient(HttpClientName);
+        // The body is consumed in full below. Keep HttpClient.Timeout active until
+        // it has arrived; ResponseHeadersRead leaves body reads without a deadline
+        // and can permanently block this producer's ordered mutation queue.
         using var response = await httpClient.SendAsync(
                 request,
-                HttpCompletionOption.ResponseHeadersRead,
+                HttpCompletionOption.ResponseContentRead,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -651,8 +654,18 @@ public sealed class SlimDataService : IDatabaseService, IAsyncDisposable
         var committedIndex = _cluster.AuditTrail.LastCommittedEntryIndex;
         if (committedIndex > 0L)
         {
-            await _cluster.AuditTrail.WaitForApplyAsync(committedIndex, cancellationToken)
-                .ConfigureAwait(false);
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(ReadBarrierTimeout);
+            try
+            {
+                await _cluster.AuditTrail.WaitForApplyAsync(committedIndex, timeout.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new SlimDataUnavailableException(
+                    "Raft local log application timed out while reading SlimData.", ex);
+            }
         }
     }
 

--- a/tests/SlimFaas.Tests/Database/SlimDataRecoveryTests.cs
+++ b/tests/SlimFaas.Tests/Database/SlimDataRecoveryTests.cs
@@ -1,0 +1,261 @@
+using System.Collections.Concurrent;
+using System.Net;
+using DotNext.IO.Log;
+using DotNext.Net.Cluster.Consensus.Raft;
+using DotNext.Net.Cluster.Consensus.Raft.StateMachine;
+using MemoryPack;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SlimData;
+using SlimFaas.Database;
+using SlimFaas.Jobs;
+using SlimFaas.Options;
+
+namespace SlimFaas.Tests.Database;
+
+public sealed class SlimDataRecoveryTests
+{
+    private static readonly TimeSpan TestDeadline = TimeSpan.FromSeconds(12);
+
+    [Theory]
+    [InlineData(SlimDataBatchMode.Global)]
+    [InlineData(SlimDataBatchMode.PartitionedByKey)]
+    public async Task Accepted_job_is_dequeued_after_response_body_timeout_and_leader_change(SlimDataBatchMode mode)
+    {
+        using var stalled = new StalledContent();
+        var requests = new ConcurrentQueue<(Uri Uri, byte[] Payload)>();
+        var popAttempts = 0;
+        var acceptedJobId = string.Empty;
+        using var handler = new Handler(async (request, token) =>
+        {
+            var bytes = await request.Content!.ReadAsByteArrayAsync(token);
+            requests.Enqueue((request.RequestUri!, bytes));
+            var batch = MemoryPackSerializer.Deserialize<SlimDataCommandBatchRequest>(bytes)!;
+            var operation = Assert.Single(batch.Operations);
+            if (operation.Kind == SlimDataBatchOperationKind.ListLeftPush)
+                acceptedJobId = operation.ElementId;
+            // The leader has committed this dequeue, but its first response stalls.
+            if (operation.Kind == SlimDataBatchOperationKind.ListRightPop &&
+                Interlocked.Increment(ref popAttempts) == 1)
+                return new(HttpStatusCode.OK) { Content = stalled };
+            return Reply(batch, acceptedJobId);
+        });
+        await using var fixture = new Fixture(handler, TimeSpan.FromSeconds(1), mode);
+        var queue = new JobQueue(fixture.Service);
+        var acceptedId = await queue.EnqueueAsync("recovery", [42]).WaitAsync(TestDeadline);
+        var dequeue = queue.DequeueAsync("recovery");
+        await stalled.Started.Task.WaitAsync(TestDeadline);
+        fixture.LeaderPort = 3263;
+        // A later mutation must stay behind the unresolved dequeue.
+        var nextJob = queue.EnqueueAsync("recovery", [43]);
+
+        var jobs = await dequeue.WaitAsync(TestDeadline);
+        await nextJob.WaitAsync(TestDeadline);
+
+        Assert.Equal(acceptedId, Assert.Single(jobs!).Id);
+        Assert.False(string.IsNullOrEmpty(acceptedId));
+        Assert.True(stalled.Disposed);
+        var sent = requests.ToArray();
+        Assert.Equal(4, sent.Length);
+        Assert.Equal(3262, sent[1].Uri.Port);
+        Assert.Equal(3263, sent[2].Uri.Port);
+        Assert.Equal(sent[1].Payload, sent[2].Payload);
+        var before = MemoryPackSerializer.Deserialize<SlimDataCommandBatchRequest>(sent[1].Payload)!;
+        var after = MemoryPackSerializer.Deserialize<SlimDataCommandBatchRequest>(sent[3].Payload)!;
+        Assert.Equal(before.Sequence + 1, after.Sequence);
+        Assert.Equal(before.ProducerId, after.ProducerId);
+        Assert.Equal(before.GenerationId, after.GenerationId);
+        Assert.NotEqual(before.RequestId, after.RequestId);
+    }
+
+    [Fact]
+    public async Task Shutdown_cancels_stalled_body_and_queued_mutations_without_retrying()
+    {
+        using var stalled = new StalledContent();
+        var attempts = 0;
+        using var handler = new Handler((_, _) =>
+        {
+            Interlocked.Increment(ref attempts);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = stalled });
+        });
+        await using var fixture = new Fixture(handler, Timeout.InfiniteTimeSpan);
+        var queue = new JobQueue(fixture.Service);
+        var first = queue.EnqueueAsync("recovery", [1]);
+        await stalled.Started.Task.WaitAsync(TestDeadline);
+        var second = queue.EnqueueAsync("recovery", [2]);
+
+        await fixture.Service.DisposeAsync().AsTask().WaitAsync(TestDeadline);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first.WaitAsync(TestDeadline));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => second.WaitAsync(TestDeadline));
+        Assert.True(stalled.Disposed);
+        Assert.Equal(1, attempts);
+    }
+
+    [Theory]
+    [InlineData("elements")]
+    [InlineData("count")]
+    [InlineData("dispatch")]
+    [InlineData("hash")]
+    public async Task Read_retries_after_local_apply_timeout_and_recovers(string readKind)
+    {
+        using var handler = new Handler((_, _) => throw new InvalidOperationException("Read must not mutate"));
+        await using var fixture = new Fixture(handler);
+        using var cleanup = new CancellationTokenSource();
+        var attempts = 0;
+        fixture.Log.WaitForApply = token =>
+            Interlocked.Increment(ref attempts) == 1 ? StallApplyAsync(token, cleanup.Token) : ValueTask.CompletedTask;
+
+        var read = ReadAsync(fixture.Service, readKind);
+        try
+        {
+            await read.WaitAsync(TestDeadline);
+            Assert.Equal(2, attempts);
+        }
+        finally
+        {
+            await cleanup.CancelAsync();
+            try { await read.WaitAsync(TestDeadline); }
+            catch (Exception) { /* Observe failures after releasing the test's stalled operation. */ }
+        }
+    }
+
+    [Fact]
+    public async Task Persistent_local_apply_timeout_is_reported_as_unavailable()
+    {
+        using var handler = new Handler((_, _) => throw new InvalidOperationException("Read must not mutate"));
+        await using var fixture = new Fixture(handler);
+        using var cleanup = new CancellationTokenSource();
+        fixture.Log.WaitForApply = token => StallApplyAsync(token, cleanup.Token);
+
+        try
+        {
+            var error = await Assert.ThrowsAsync<SlimDataUnavailableException>(() =>
+                fixture.Service.ListCountAsync("Job:recovery", [CountType.Available])
+                    .WaitAsync(TimeSpan.FromSeconds(30)));
+            Assert.Contains("local", error.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            await cleanup.CancelAsync();
+        }
+    }
+
+    private static async ValueTask StallApplyAsync(CancellationToken token, CancellationToken cleanup)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, cleanup);
+        await Task.Delay(Timeout.InfiniteTimeSpan, linked.Token);
+    }
+
+    private static async Task ReadAsync(SlimDataService service, string kind)
+    {
+        switch (kind)
+        {
+            case "elements": Assert.Empty(await service.ListCountElementAsync("Job:recovery", [CountType.Available])); break;
+            case "count": Assert.Equal(0, await service.ListCountAsync("Job:recovery", [CountType.Available])); break;
+            case "dispatch": Assert.Equal(QueueDispatchState.Empty, await service.GetQueueDispatchStateAsync("Job:recovery")); break;
+            case "hash": Assert.Empty(await service.HashGetAllAsync("recovery")); break;
+        }
+    }
+
+    private static HttpResponseMessage Reply(SlimDataCommandBatchRequest request, string acceptedJobId)
+    {
+        var operation = Assert.Single(request.Operations);
+        var response = new SlimDataCommandBatchResponse
+        {
+            ProducerId = request.ProducerId,
+            Sequence = request.Sequence,
+            RequestId = request.RequestId,
+            Results = [new SlimDataBatchOperationResult
+            {
+                Kind = operation.Kind, RequestId = operation.RequestId, Applied = true,
+                ElementId = operation.ElementId,
+                QueueItems = [new QueueData(acceptedJobId, [42], 1, false, 0, 0, "")]
+            }]
+        };
+        return new(HttpStatusCode.OK) { Content = new ByteArrayContent(MemoryPackSerializer.Serialize(response)) };
+    }
+
+    private sealed class Fixture : IAsyncDisposable
+    {
+        private readonly string _directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        private readonly SlimPersistentState _state;
+        private readonly ServiceProvider _services;
+        private readonly HttpClient _client;
+        public Mock<IRaftCluster> Cluster { get; } = new();
+        public ControlledLog Log { get; }
+        public int LeaderPort { get; set; } = 3262;
+        public SlimDataService Service { get; }
+
+        public Fixture(HttpMessageHandler handler, TimeSpan? timeout = null, SlimDataBatchMode mode = SlimDataBatchMode.Global)
+        {
+            Directory.CreateDirectory(_directory);
+            _state = new SlimPersistentState(_directory);
+            Log = new ControlledLog(new WriteAheadLog.Options { Location = Path.Combine(_directory, "wal") }, _state);
+            _services = new ServiceCollection().AddSingleton(_state).BuildServiceProvider();
+            var member = new Mock<IRaftClusterMember>();
+            member.SetupGet(m => m.EndPoint).Returns(() => new UriEndPoint(new Uri($"http://127.0.0.1:{LeaderPort}")));
+            Cluster.SetupGet(c => c.Leader).Returns(member.Object);
+            Cluster.SetupGet(c => c.AuditTrail).Returns(Log);
+            // Follower reads do not need a leader lease after local application.
+            Cluster.SetupGet(c => c.LeadershipToken).Returns(new CancellationToken(true));
+            var compatibility = new Mock<ISlimDataProtocolCompatibility>();
+            compatibility.SetupGet(c => c.IsCompatible).Returns(true);
+            _client = new HttpClient(handler, disposeHandler: false) { Timeout = timeout ?? TimeSpan.FromSeconds(10) };
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(f => f.CreateClient(SlimDataService.HttpClientName)).Returns(_client);
+            Service = new SlimDataService(factory.Object, _services, Cluster.Object, compatibility.Object,
+                new SlimDataInfo(3262), Microsoft.Extensions.Options.Options.Create(new SlimDataOptions { BatchMode = mode }),
+                NullLogger<SlimDataService>.Instance);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Service.DisposeAsync();
+            _client.Dispose();
+            await _services.DisposeAsync();
+            await Log.DisposeAsync();
+            await _state.DisposeAsync();
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    // Keep DotNext's persistent-state implementation (its internal setter cannot
+    // be proxied by Castle), overriding only the local-application observation.
+    private sealed class ControlledLog(WriteAheadLog.Options options, IStateMachine state)
+        : WriteAheadLog(options, state), IAuditTrail
+    {
+        public Func<CancellationToken, ValueTask> WaitForApply { get; set; } = _ => ValueTask.CompletedTask;
+        long IAuditTrail.LastCommittedEntryIndex => 7L;
+        ValueTask IAuditTrail.WaitForApplyAsync(long index, CancellationToken token)
+        {
+            Assert.Equal(7L, index);
+            return WaitForApply(token);
+        }
+        ValueTask<TResult> IAuditTrail.ReadAsync<TResult>(ILogEntryConsumer<ILogEntry, TResult> reader,
+            long startIndex, long endIndex, CancellationToken token) => throw new NotSupportedException();
+    }
+
+    private sealed class Handler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> send) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => send(request, cancellationToken);
+    }
+
+    private sealed class StalledContent : HttpContent
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool Disposed { get; private set; }
+        protected override bool TryComputeLength(out long length) { length = 0; return false; }
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => SerializeToStreamAsync(stream, context, CancellationToken.None);
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+        protected override void Dispose(bool disposing) { Disposed = true; base.Dispose(disposing); }
+    }
+}

--- a/tests/SlimFaas.Tests/Local/test_job_recovery.py
+++ b/tests/SlimFaas.Tests/Local/test_job_recovery.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Check job recovery across a temporary leader pause, without restarting nodes.
+
+Requires Linux/macOS, Python 3, lsof and a built SlimFaas runtime. Runs an isolated
+three-node cluster with temporary state and loopback ports. Usage from the repo:
+    python3 tests/SlimFaas.Tests/Local/test_job_recovery.py [path/to/SlimFaas]
+The default runtime is the Debug net10.0 DLL. The script also acts as its own job
+workload; no external function, Kubernetes cluster or container engine is needed.
+"""
+import importlib.util
+import os
+from pathlib import Path
+import re
+import random
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+ROOT = Path(__file__).resolve().parents[3]
+if len(sys.argv) > 1 and sys.argv[1] == '--execute':
+    root, marker = Path(sys.argv[2]), sys.argv[3]
+    with (root / 'starts').open('a') as out:
+        out.write(marker + '\n')
+    deadline = time.monotonic() + 90
+    while not (root / 'release').exists():
+        if time.monotonic() > deadline:
+            raise TimeoutError('Job release gate was not opened')
+        time.sleep(.1)
+    sys.exit(0)
+
+if os.name == 'nt':
+    raise SystemExit('This test requires POSIX SIGSTOP/SIGCONT and lsof.')
+
+spec = importlib.util.spec_from_file_location('job_test', ROOT / 'tests/SlimFaas.Tests/Local/test_job_concurrency.py')
+helper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helper)
+
+def ports():
+    for _ in range(100):
+        sockets = []
+        try:
+            first = socket.socket()
+            first.bind(('127.0.0.1', random.randrange(20000, 28000)))
+            base = first.getsockname()[1]
+            sockets.append(first)
+            for port in range(base + 1, base + 7):
+                sock = socket.socket()
+                sockets.append(sock)
+                sock.bind(('127.0.0.1', port))
+            return base
+        except OSError:
+            pass
+        finally:
+            for sock in sockets:
+                sock.close()
+    raise RuntimeError('No contiguous ports available')
+
+def listener_pid(port):
+    return int(subprocess.check_output(['lsof', '-t', '-iTCP:' + str(port), '-sTCP:LISTEN'], text=True).strip())
+
+def leader(raft_ports, excluded=None):
+    for port in raft_ports:
+        if port == excluded:
+            continue
+        try:
+            with urllib.request.urlopen(f'http://127.0.0.1:{port}/SlimData/leader', timeout=2) as response:
+                match = re.search(r'Leader address is http://127\.0\.0\.1:(\d+)', response.read().decode())
+                if match:
+                    return int(match.group(1))
+        except (urllib.error.URLError, TimeoutError, ConnectionError):
+            pass
+    return None
+
+runtime = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / 'src/SlimFaas/bin/Debug/net10.0/SlimFaas.dll'
+command = ['dotnet', str(runtime)] if runtime.suffix == '.dll' else [str(runtime)]
+with tempfile.TemporaryDirectory(prefix='slimfaas-job-recovery-') as temporary:
+    root = Path(temporary)
+    base = ports()
+    raft_ports = list(range(base + 4, base + 7))
+    manifest = {
+        'schemaVersion': 1, 'name': 'job-recovery',
+        'cluster': {'nodes': 3, 'entrypointPort': base, 'nodeHttpPortBase': base + 1, 'raftPortBase': base + 4},
+        'state': {'mode': 'persistent', 'directory': str(root / 'state')},
+        'jobs': {'recovery': {
+            'command': [sys.executable, str(Path(__file__).resolve()), '--execute', str(root)],
+            'workingDirectory': str(root),
+            'annotations': {'SlimFaas/Job': 'true', 'SlimFaas/DefaultVisibility': 'Public', 'SlimFaas/NumberParallelJob': '2'},
+            'ttlSecondsAfterFinished': 3600, 'backoffLimit': 0, 'restartPolicy': 'Never'}}}
+    manifest_path = root / 'local.yaml'
+    manifest_path.write_text('\n'.join(helper.yaml_mapping(manifest)) + '\n')
+    subprocess.run([*command, 'local', 'validate', '-f', str(manifest_path)], check=True)
+    with (root / 'supervisor.log').open('w') as log:
+        process = subprocess.Popen([*command, 'local', 'up', '-f', str(manifest_path)], stdout=log,
+                                   stderr=subprocess.STDOUT, cwd=ROOT, start_new_session=True)
+        paused = None
+        try:
+            for port in range(base, base + 4):
+                helper.wait_for_ready(f'http://127.0.0.1:{port}', process)
+            pids = {port: listener_pid(port) for port in raft_ports}
+            old_leader = leader(raft_ports)
+            assert old_leader in raft_ports, old_leader
+            follower_port = next(port for port in raft_ports if port != old_leader) - 3
+            api = f'http://127.0.0.1:{follower_port}'
+            expected = {}
+            for index in range(6):
+                created = helper.request(api, '/job/recovery', {'Args': [f'before-{index}']})
+                expected[created['Id']] = 'Succeeded'
+            paused = pids[old_leader]
+            assert os.getpgid(paused) == process.pid
+            os.kill(paused, signal.SIGSTOP)
+            print(f'Paused leader {old_leader}, PID {paused}; six accepted jobs.', flush=True)
+            deadline = time.monotonic() + 45
+            new_leader = None
+            while time.monotonic() < deadline:
+                new_leader = leader(raft_ports, excluded=old_leader)
+                if new_leader and new_leader != old_leader:
+                    break
+                time.sleep(.25)
+            assert new_leader and new_leader != old_leader, 'No replacement leader elected'
+            print(f'Leader changed to {new_leader}; submitting six more jobs.', flush=True)
+            api = f'http://127.0.0.1:{new_leader - 3}'
+            for index in range(6):
+                created = helper.request(api, '/job/recovery', {'Args': [f'during-{index}']})
+                expected[created['Id']] = 'Succeeded'
+            os.kill(paused, signal.SIGCONT)
+            paused = None
+            (root / 'release').touch()
+            helper.wait_for_jobs(api, 'recovery', expected, process)
+            helper.wait_for_ready(f'http://127.0.0.1:{old_leader - 3}', process)
+            for index in range(6):
+                created = helper.request(api, '/job/recovery', {'Args': [f'after-{index}']})
+                expected[created['Id']] = 'Succeeded'
+            helper.wait_for_jobs(api, 'recovery', expected, process)
+            starts = (root / 'starts').read_text().splitlines()
+            assert len(starts) == len(set(starts)) == 18, starts
+            assert pids == {port: listener_pid(port) for port in raft_ports}, 'A node restarted'
+            print('PASS: 18/18 accepted jobs succeeded once across three waves; leader changed; all three node PIDs unchanged.', flush=True)
+        except BaseException:
+            log.flush()
+            print((root / 'supervisor.log').read_text(errors='replace')[-16000:])
+            raise
+        finally:
+            if paused is not None:
+                os.kill(paused, signal.SIGCONT)
+            helper.stop(process)


### PR DESCRIPTION
Fixes #351

A SlimData queue consumer can remain blocked after a transient interruption while other nodes continue accepting jobs. `WaitForApplyAsync` had no deadline, and `ResponseHeadersRead` stopped the internal HTTP timeout at the headers even though the complete response body was still required. A stalled body therefore prevented the ordered mutation queue from retrying.

Bound local log-application waits to five seconds and report expiration as `SlimDataUnavailableException`, allowing the existing read retries and subsequent worker cycles to run. Buffer the batch response within `HttpClient.SendAsync` so its existing timeout and shutdown cancellation cover the body as well. Retries retain the same serialized batch, producer/generation/sequence/request IDs and operation order, and resolve the leader again. No API, configuration, dependency or job concurrency changes.

The tests reproduce accepted jobs stuck at dequeue and stalled local reads on the original code. This confirms these blocking paths; without logs from the reported development incident, it does **not** establish which path caused that specific incident. The retained-job concurrency fix is already on main and is preserved.

Validation:

- Six regression cases fail with `TimeoutException` against the original implementation; all eight recovery/shutdown tests pass with the fix, covering both global and partitioned batching, a leader change, byte-identical retry payloads, ordering, response disposal, read recovery and exhausted read retries.
- Targeted tests: **173 passed**. Full `dotnet test`: **1,453 passed**, including SlimData's command-batch deduplication tests and retained-job concurrency tests.
- Repeatable three-node test in `tests/SlimFaas.Tests/Local/test_job_recovery.py`: **18/18 jobs succeeded once** across submissions before, during and after a `SIGSTOP`/`SIGCONT` interruption of the leader. A new leader was elected; all three node PIDs remained unchanged. Passed with both managed and native AOT runtimes.
- `dotnet publish src/SlimFaas/SlimFaas.csproj -c Release -r osx-arm64 -p:PublishAot=true`: passed (existing dependency trimming/AOT warnings).
- Documentation site: frozen-lockfile install and build passed; 21 pages and 1,370 local links/assets checked.
- Native local demo: manifest validation passed; `/status-functions` and `/function/fibonacci1/hello/local` returned HTTP 200.
- AOT three-node `slimdata-mixed` smoke benchmark (2s warmup, 5s load, concurrency 12): **2,040 operations, zero failures**, final data validation passed. This is a smoke check, not a comparative performance claim.

GitHub validation for commit `577ff8b500897227363077a3ba67c1b5cd33bf61`:

- [Main CI workflow](https://github.com/SlimPlanet/SlimFaas/actions/runs/34521612485): **success**, including Linux unit tests, Windows tests/SonarCloud, all nine native AOT builds and all nine Docker image builds. CI logs confirm 1,453 .NET tests passing on both Linux and Windows.
- [Dashboard and documentation workflow](https://github.com/SlimPlanet/SlimFaas/actions/runs/34521612578): **success**.
- **23 executed workflow jobs passed** in total. Release/deployment jobs excluded by the PR event were skipped as configured. SonarCloud Code Analysis, DCO and FOSSA License Compliance also passed.
