### PR TITLE
test(SlimData): make the dynamic timing batcher test deterministic

### DIFF
--- a/tests/SlimData.Tests/MultiRateAdaptiveBatcherTests.cs
+++ b/tests/SlimData.Tests/MultiRateAdaptiveBatcherTests.cs
@@ -108,14 +108,21 @@ public sealed class MultiRateAdaptiveBatcherTests
         Assert.Equal(0, drained.Bytes);
     }
 
+    /// <summary>
+    /// Runs on the manual clock: the first batch only flushes once the fake time crosses the
+    /// coalescence window, and after the provider drops both delays the next item must
+    /// complete without the clock moving at all. A wall-clock threshold measured the CI
+    /// runner instead of the batcher (issue #356).
+    /// </summary>
     [Fact]
     public async Task Dynamic_timing_provider_can_remove_local_delay_and_coalescence()
     {
+        var time = new ManualTimeProvider();
         var timing = new AdaptiveBatchTiming(
             TimeSpan.FromMilliseconds(100),
             TimeSpan.FromMilliseconds(100));
         var batchSizes = new List<int>();
-        await using var batcher = new MultiRateAdaptiveBatcher();
+        await using var batcher = new MultiRateAdaptiveBatcher(timeProvider: time);
         batcher.RegisterKind<int, int>(
             "dynamic",
             (requests, _) =>
@@ -131,22 +138,24 @@ public sealed class MultiRateAdaptiveBatcherTests
 
         var first = batcher.EnqueueAsync<int, int>("dynamic", 1);
         var second = batcher.EnqueueAsync<int, int>("dynamic", 2);
+        await time.WaitForTimerAsync(TimeSpan.FromMilliseconds(100));
+        time.Advance(TimeSpan.FromMilliseconds(99));
+        Assert.False(first.IsCompleted);
+        Assert.False(second.IsCompleted);
+
+        time.Advance(TimeSpan.FromMilliseconds(1));
         var firstBatchResults = await Task
             .WhenAll(first, second)
             .WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Equal(new[] { 1, 2 }, firstBatchResults);
         Assert.Equal(2, Assert.Single(batchSizes));
 
+        // Zero delay and zero coalescence: the item must flush without the clock advancing.
         timing = new AdaptiveBatchTiming(TimeSpan.Zero, TimeSpan.Zero);
-        var startedAt = System.Diagnostics.Stopwatch.GetTimestamp();
         Assert.Equal(3, await batcher
             .EnqueueAsync<int, int>("dynamic", 3)
             .WaitAsync(TimeSpan.FromSeconds(5)));
-        var elapsed = System.Diagnostics.Stopwatch.GetElapsedTime(startedAt);
-
-        Assert.True(
-            elapsed < TimeSpan.FromMilliseconds(75),
-            $"Expected the fast path below 75 ms, measured {elapsed.TotalMilliseconds:F1} ms.");
+        Assert.Equal(new[] { 2, 1 }, batchSizes);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the flaky test `MultiRateAdaptiveBatcherTests.Dynamic_timing_provider_can_remove_local_delay_and_coalescence` reported in #356.

The test measured wall-clock time on the system clock and asserted that the "fast path" completed in under 75 ms. On loaded GitHub runners, timer granularity and thread-pool latency alone exceed that bound (160 ms on `main` run 34596932070, 786 ms on the PR #343 SonarCloud job), so the assertion measured the runner rather than the batcher.

## Change

- The test now runs on the `ManualTimeProvider` already used by the other timing tests of the file.
- The first batch (two items, 100 ms delay and 100 ms coalescence window) is asserted to stay pending at 99 ms of fake time and to flush at 100 ms.
- After the timing provider drops both delays to zero, the third item must complete **without the fake clock advancing at all**, which is the property the test was meant to check. If the batcher still waited on its delay or coalescence window, the item would never complete and the 5 s `WaitAsync` guard would fail the test.
- The `Stopwatch` and the 75 ms threshold are gone.

No production code is changed.

## Validation

- `dotnet test tests/SlimData.Tests --filter MultiRateAdaptiveBatcherTests` run five times in a row: 9/9 passed each time, ~250 ms per run instead of ~1 s.

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jxsWZRveanyycrr9JhJjZ