### PR TITLE
test(SlimFaas): give the child process tree test explicit deadlines

### DIFF
--- a/tests/SlimFaas.Tests/Local/ManagedLocalProcessTests.cs
+++ b/tests/SlimFaas.Tests/Local/ManagedLocalProcessTests.cs
@@ -117,7 +117,7 @@ public sealed class ManagedLocalProcessTests
 
         await process.StopAsync(null, TimeSpan.FromSeconds(5));
 
-        await WaitForAsync(() => !IsRunning(childPid));
+        await WaitForAsync(() => !IsRunning(childPid), ShutdownDeadline);
         Assert.True(process.HasExited);
     }
 
@@ -138,7 +138,7 @@ public sealed class ManagedLocalProcessTests
                 // Wait for a readable PID within the existing bounded startup deadline.
                 return false;
             }
-        });
+        }, StartupDeadline);
         return childPid;
     }
 
@@ -159,16 +159,26 @@ public sealed class ManagedLocalProcessTests
         }
     }
 
-    private static async Task WaitForAsync(Func<bool> condition)
+    // Spawning PowerShell on a shared Windows runner (with coverage instrumentation in the
+    // SonarCloud job) can take several seconds, so the startup deadline is generous. A
+    // passing run is not slower: the condition is polled every 100 ms (issue #359).
+    private static readonly TimeSpan StartupDeadline = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan ShutdownDeadline = TimeSpan.FromSeconds(30);
+
+    private static async Task WaitForAsync(Func<bool> condition, TimeSpan timeout)
     {
-        for (var attempt = 0; attempt < 100; attempt++)
+        long startedAt = Stopwatch.GetTimestamp();
+        while (true)
         {
             if (condition())
                 return;
+            if (Stopwatch.GetElapsedTime(startedAt) >= timeout)
+                break;
             await Task.Delay(100);
         }
 
-        throw new Xunit.Sdk.XunitException("Condition was not reached before the timeout.");
+        throw new Xunit.Sdk.XunitException(
+            $"Condition was not reached within {timeout.TotalSeconds:F0} s.");
     }
 
     private sealed class TemporaryDirectory : IDisposable, IAsyncDisposable
@@ -205,7 +215,7 @@ public sealed class ManagedLocalProcessTests
                 {
                     return false;
                 }
-            });
+            }, ShutdownDeadline);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the flaky test `ManagedLocalProcessTests.StopAsync_TerminatesTheWholeChildProcessTree` reported in #359.

The test polled for the child PID file with a fixed budget of 100 × 100 ms = 10 s. On the shared Windows runner of the SonarCloud job, where the test host runs under coverage instrumentation, a PowerShell cold start plus `Start-Process` can exceed that budget, so the test failed on the startup wait before reaching its actual assertion (the child is gone after `StopAsync`). It failed this way on `main` (run 34572415125) and on PR #343 (run 34599734320, second attempt), while passing in the Unit Tests job on the same heads.

## Change

- `WaitForAsync` takes an explicit timeout and reports it in the failure message.
- Process startup (PID file) waits up to 60 s; the post-stop check and the temporary directory cleanup wait up to 30 s.
- The condition is still polled every 100 ms, so a passing run is as fast as before. Only the failure deadline changes.

No production code is changed.

## Validation

- `dotnet test tests/SlimFaas.Tests --filter ManagedLocalProcessTests` run three times in a row: 4/4 passed each time, about 1 s per run.

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jxsWZRveanyycrr9JhJjZ